### PR TITLE
Namespace ISR cache artifacts by build

### DIFF
--- a/src/server/isr-cache.ts
+++ b/src/server/isr-cache.ts
@@ -1,0 +1,34 @@
+const ISR_CACHE_PREFIX = "/_nextane/isr";
+
+function buildPrefix(buildId: string): string {
+  return `${ISR_CACHE_PREFIX}/${encodeURIComponent(buildId)}`;
+}
+
+/**
+ * Give every deployment a distinct URL in the Workers cache. This uses the
+ * default URL cache key instead of `cf.cacheKey`, which is Enterprise-only.
+ */
+export function namespaceIsrCacheRequest(
+  request: Request,
+  buildId: string,
+): Request {
+  const url = new URL(request.url);
+  url.pathname = `${buildPrefix(buildId)}${url.pathname}`;
+  url.search = "";
+  return new Request(url, request);
+}
+
+/** Restore the canonical page URL before the cached entrypoint renders it. */
+export function restoreIsrArtifactRequest(
+  request: Request,
+  buildId: string,
+): Request {
+  const url = new URL(request.url);
+  const prefix = buildPrefix(buildId);
+  if (!url.pathname.startsWith(`${prefix}/`)) {
+    throw new Error("ISR cache request is outside the current build namespace");
+  }
+  url.pathname = url.pathname.slice(prefix.length);
+  url.search = "";
+  return new Request(url, request);
+}

--- a/test/unit/isr-cache.test.ts
+++ b/test/unit/isr-cache.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  namespaceIsrCacheRequest,
+  restoreIsrArtifactRequest,
+} from "../../src/server/isr-cache";
+
+describe("Workers ISR cache namespaces", () => {
+  it("uses the natural URL cache key to isolate every build", async () => {
+    const canonical = new Request(
+      "https://nextane.internal/posts/octane?attacker=ignored",
+      {
+        headers: { "x-nextane-only-cached": "1" },
+      },
+    );
+
+    const first = namespaceIsrCacheRequest(canonical, "build-one");
+    const second = namespaceIsrCacheRequest(canonical, "build/two");
+
+    expect(first.url).toBe(
+      "https://nextane.internal/_nextane/isr/build-one/posts/octane",
+    );
+    expect(second.url).toBe(
+      "https://nextane.internal/_nextane/isr/build%2Ftwo/posts/octane",
+    );
+    expect(first.url).not.toBe(second.url);
+
+    const restored = restoreIsrArtifactRequest(first, "build-one");
+    expect(restored.url).toBe("https://nextane.internal/posts/octane");
+    expect(restored.headers.get("x-nextane-only-cached")).toBe("1");
+  });
+
+  it("rejects cache requests from another build namespace", () => {
+    const request = new Request(
+      "https://nextane.internal/_nextane/isr/old-build/",
+    );
+    expect(() => restoreIsrArtifactRequest(request, "current-build")).toThrow(
+      "outside the current build namespace",
+    );
+  });
+});

--- a/worker.ts
+++ b/worker.ts
@@ -13,6 +13,10 @@ import {
   createNextaneHandler,
   type NextaneEnvironment,
 } from "./src/server/handler";
+import {
+  namespaceIsrCacheRequest,
+  restoreIsrArtifactRequest,
+} from "./src/server/isr-cache";
 
 const manifest = {
   buildId,
@@ -60,7 +64,7 @@ async function loadLocalArtifact(request: Request): Promise<Response> {
 
 export class IsrArtifact extends WorkerEntrypoint<NextaneEnvironment> {
   fetch(request: Request) {
-    return handleIsrArtifact(request);
+    return handleIsrArtifact(restoreIsrArtifactRequest(request, buildId));
   }
 }
 
@@ -69,12 +73,9 @@ export default {
     const handle = createNextaneHandler(manifest, {
       async loadCachedArtifact(artifactRequest) {
         if (import.meta.env.DEV) return loadLocalArtifact(artifactRequest);
-        const url = new URL(artifactRequest.url);
-        return ctx.exports.IsrArtifact.fetch(artifactRequest, {
-          cf: {
-            cacheKey: `${buildId}:${url.pathname}`,
-          },
-        });
+        return ctx.exports.IsrArtifact.fetch(
+          namespaceIsrCacheRequest(artifactRequest, buildId),
+        );
       },
       async revalidatePath(pathname) {
         localArtifactCache.delete(`${buildId}:${pathname}`);


### PR DESCRIPTION
Prevents cached ISR artifacts from surviving across deployments by putting the build ID in the natural Workers cache URL. Removes reliance on the Enterprise-only custom cache-key override and adds regression coverage for cross-build isolation and namespace validation.