### PR TITLE
Resolve CodeQL hardening findings

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -621,12 +621,28 @@ function clientPageFileId(filePath: string): string {
   return `${viteFileId(filePath)}?${CLIENT_PAGE_QUERY}`;
 }
 
+export function javascriptStringLiteral(value: string): string {
+  let literal = '"';
+  for (let index = 0; index < value.length; index += 1) {
+    literal += `\\u${value.charCodeAt(index).toString(16).padStart(4, "0")}`;
+  }
+  return `${literal}"`;
+}
+
+function serializeJavascriptValue(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    throw new TypeError("Cannot serialize undefined into a virtual module");
+  }
+  return `JSON.parse(${javascriptStringLiteral(json)})`;
+}
+
 function serializePublicRoute(route: {
   route: string;
   regexSource: string;
   params: unknown;
 }): string {
-  return JSON.stringify({
+  return serializeJavascriptValue({
     route: route.route,
     regexSource: route.regexSource,
     params: route.params,
@@ -640,17 +656,21 @@ async function clientManifestSource(root: string): Promise<string> {
 
   const loaderEntries = routes.map(
     (route) =>
-      `${JSON.stringify(route.route)}: () => import(${JSON.stringify(clientPageFileId(route.filePath))})`,
+      `${javascriptStringLiteral(route.route)}: () => import(${javascriptStringLiteral(clientPageFileId(route.filePath))})`,
   );
 
   return `
 export const routes = [${routes.map(serializePublicRoute).join(",")}];
 export const pageLoaders = {${loaderEntries.join(",")}};
 export const appLoader = ${
-    appPath ? `() => import(${JSON.stringify(clientPageFileId(appPath))})` : "null"
+    appPath
+      ? `() => import(${javascriptStringLiteral(clientPageFileId(appPath))})`
+      : "null"
   };
 export const errorLoader = ${
-    errorPath ? `() => import(${JSON.stringify(clientPageFileId(errorPath))})` : "null"
+    errorPath
+      ? `() => import(${javascriptStringLiteral(clientPageFileId(errorPath))})`
+      : "null"
   };
 `;
 }
@@ -667,22 +687,28 @@ async function serverManifestSource(
 
   const routeEntries = routes.map(
     (route, index) =>
-      `{...${serializePublicRoute(route)}, kind:${JSON.stringify(route.kind)}, load: () => import(${JSON.stringify(viteFileId(route.filePath))}), id:${index}}`,
+      `{...${serializePublicRoute(route)}, kind:${javascriptStringLiteral(route.kind)}, load: () => import(${javascriptStringLiteral(viteFileId(route.filePath))}), id:${index}}`,
   );
 
   return `
-export const buildId = ${JSON.stringify(buildId)};
+export const buildId = ${javascriptStringLiteral(buildId)};
 export const routes = [${routeEntries.join(",")}];
 export const loadApp = ${
-    appPath ? `() => import(${JSON.stringify(viteFileId(appPath))})` : "null"
+    appPath
+      ? `() => import(${javascriptStringLiteral(viteFileId(appPath))})`
+      : "null"
   };
 export const loadDocument = ${
-    documentPath ? `() => import(${JSON.stringify(viteFileId(documentPath))})` : "null"
+    documentPath
+      ? `() => import(${javascriptStringLiteral(viteFileId(documentPath))})`
+      : "null"
   };
 export const loadError = ${
-    errorPath ? `() => import(${JSON.stringify(viteFileId(errorPath))})` : "null"
+    errorPath
+      ? `() => import(${javascriptStringLiteral(viteFileId(errorPath))})`
+      : "null"
   };
-export const config = ${JSON.stringify(routingConfig)};
+export const config = ${serializeJavascriptValue(routingConfig)};
 `;
 }
 

--- a/src/runtime/router.ts
+++ b/src/runtime/router.ts
@@ -116,6 +116,34 @@ function routeMatchesVisiblePath(route: string, pathname: string): boolean {
   );
 }
 
+function interpolateRouteQuery(
+  route: string,
+  query: NonNullable<UrlObject["query"]>,
+): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < route.length) {
+    const opening = route.indexOf("[", cursor);
+    if (opening === -1) break;
+    const closing = route.indexOf("]", opening + 1);
+    if (closing === -1) break;
+
+    result += route.slice(cursor, opening);
+    const name = route.slice(opening + 1, closing);
+    const replacement = query[name];
+    if (replacement === undefined || Array.isArray(replacement)) {
+      result += route.slice(opening, closing + 1);
+    } else {
+      delete query[name];
+      result += encodeURIComponent(String(replacement));
+    }
+    cursor = closing + 1;
+  }
+
+  return `${result}${route.slice(cursor)}`;
+}
+
 function formatUrlObject(value: UrlObject): string {
   const state = currentState();
   const current = new URL(state.asPath, "https://nextane.local");
@@ -126,20 +154,7 @@ function formatUrlObject(value: UrlObject): string {
     !value.pathname &&
     routeMatchesVisiblePath(state.route, current.pathname)
   ) {
-    pathname = state.route.replace(
-      /\[([^\]]+)\]/g,
-      (segment, name: string) => {
-        const replacement = query[name];
-        if (
-          replacement === undefined ||
-          Array.isArray(replacement)
-        ) {
-          return segment;
-        }
-        delete query[name];
-        return encodeURIComponent(String(replacement));
-      },
-    );
+    pathname = interpolateRouteQuery(state.route, query);
   }
 
   const search = new URLSearchParams();
@@ -171,13 +186,24 @@ function normalizeTrailingSlash(value: string): string {
   const pathname = boundary === -1 ? value : value.slice(0, boundary);
   const suffix = boundary === -1 ? "" : value.slice(boundary);
   if (pathname === "/") return value;
-  const fileLike = /\/[^/]+\.[^/]+\/?$/.test(pathname);
+  const segmentEnd = pathname.endsWith("/")
+    ? pathname.length - 1
+    : pathname.length;
+  const segmentStart = pathname.lastIndexOf("/", segmentEnd - 1) + 1;
+  const fileLike = pathname.slice(segmentStart, segmentEnd).includes(".");
+  let withoutTrailingSlash = pathname;
+  while (
+    withoutTrailingSlash.length > 1 &&
+    withoutTrailingSlash.endsWith("/")
+  ) {
+    withoutTrailingSlash = withoutTrailingSlash.slice(0, -1);
+  }
   const normalized =
     currentState().trailingSlash && !fileLike
       ? pathname.endsWith("/")
         ? pathname
         : `${pathname}/`
-      : pathname.replace(/\/+$/, "");
+      : withoutTrailingSlash;
   return `${normalized}${suffix}`;
 }
 
@@ -288,10 +314,7 @@ const Router: NextaneRouter & {
     ) {
       return false;
     }
-    if (!runtime.navigate) {
-      if (typeof window !== "undefined") window.location.assign(destination);
-      return false;
-    }
+    if (!runtime.navigate) return false;
     return runtime.navigate(destination, "push", options, href);
   },
   async replace(url, as, options) {
@@ -303,10 +326,7 @@ const Router: NextaneRouter & {
     ) {
       return false;
     }
-    if (!runtime.navigate) {
-      if (typeof window !== "undefined") window.location.replace(destination);
-      return false;
-    }
+    if (!runtime.navigate) return false;
     return runtime.navigate(destination, "replace", options, href);
   },
   async prefetch(url) {

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -438,7 +438,112 @@ function escapeHtml(value: string): string {
 }
 
 function replaceLiteral(source: string, search: string, replacement: string): string {
-  return source.replace(search, () => replacement);
+  const index = source.indexOf(search);
+  if (index === -1) return source;
+  return `${source.slice(0, index)}${replacement}${source.slice(
+    index + search.length,
+  )}`;
+}
+
+interface HtmlElementRange {
+  end: number;
+  innerEnd: number;
+  innerStart: number;
+  outer: string;
+  start: number;
+}
+
+function htmlTagEnd(source: string, start: number): number {
+  let quote = "";
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) quote = "";
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function isHtmlTagBoundary(character: string | undefined): boolean {
+  return (
+    character === undefined ||
+    character === ">" ||
+    character === "/" ||
+    character === " " ||
+    character === "\n" ||
+    character === "\r" ||
+    character === "\t" ||
+    character === "\f"
+  );
+}
+
+function findHtmlElements(source: string, tagName: string): HtmlElementRange[] {
+  const lowerSource = source.toLowerCase();
+  const opening = `<${tagName.toLowerCase()}`;
+  const closing = `</${tagName.toLowerCase()}`;
+  const elements: HtmlElementRange[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const start = lowerSource.indexOf(opening, cursor);
+    if (start === -1) break;
+    if (!isHtmlTagBoundary(lowerSource[start + opening.length])) {
+      cursor = start + opening.length;
+      continue;
+    }
+
+    const openingEnd = htmlTagEnd(source, start + opening.length);
+    if (openingEnd === -1) break;
+
+    let closingStart = lowerSource.indexOf(closing, openingEnd + 1);
+    while (
+      closingStart !== -1 &&
+      !isHtmlTagBoundary(lowerSource[closingStart + closing.length])
+    ) {
+      closingStart = lowerSource.indexOf(
+        closing,
+        closingStart + closing.length,
+      );
+    }
+    if (closingStart === -1) break;
+
+    const closingEnd = htmlTagEnd(source, closingStart + closing.length);
+    if (closingEnd === -1) break;
+
+    elements.push({
+      start,
+      end: closingEnd + 1,
+      innerStart: openingEnd + 1,
+      innerEnd: closingStart,
+      outer: source.slice(start, closingEnd + 1),
+    });
+    cursor = closingEnd + 1;
+  }
+
+  return elements;
+}
+
+function htmlElementContent(source: string, tagName: string): string {
+  const element = findHtmlElements(source, tagName)[0];
+  return element
+    ? source.slice(element.innerStart, element.innerEnd)
+    : "";
+}
+
+function stripHtmlElements(source: string, tagName: string): string {
+  const elements = findHtmlElements(source, tagName);
+  if (elements.length === 0) return source;
+  let result = "";
+  let cursor = 0;
+  for (const element of elements) {
+    result += source.slice(cursor, element.start);
+    cursor = element.end;
+  }
+  return `${result}${source.slice(cursor)}`;
 }
 
 function hasSetCookie(response: ResponseSnapshot | undefined): boolean {
@@ -516,20 +621,22 @@ function renderDocumentShell(
   artifact: RenderArtifact,
   dataScript: string,
 ): string {
-  const templateHead =
-    /<head[^>]*>([\s\S]*?)<\/head>/i.exec(template)?.[1] ?? "";
-  const hydratedHead = replaceLiteral(
+  const templateHead = htmlElementContent(template, "head");
+  const hydratedHead = stripHtmlElements(
     replaceLiteral(
-      templateHead,
-      "<!--nextane-head-->",
-      stampManagedHead(artifact.head ?? ""),
+      replaceLiteral(
+        templateHead,
+        "<!--nextane-head-->",
+        stampManagedHead(artifact.head ?? ""),
+      ),
+      "<!--nextane-styles-->",
+      artifact.css ?? "",
     ),
-    "<!--nextane-styles-->",
-    artifact.css ?? "",
-  ).replace(/<script\b[\s\S]*?<\/script>/gi, () => "");
-  const templateScripts = [...template.matchAll(/<script\b[\s\S]*?<\/script>/gi)]
-    .map((match) => match[0])
-    .filter((script) => /\bsrc=/.test(script))
+    "script",
+  );
+  const templateScripts = findHtmlElements(template, "script")
+    .map((element) => element.outer)
+    .filter((script) => attributeValue(script, "src") !== undefined)
     .join("");
 
   let html = shell;

--- a/test/unit/handler.test.ts
+++ b/test/unit/handler.test.ts
@@ -62,9 +62,10 @@ const assets = {
         <meta charset="utf-8">
         <!--nextane-head--><!--nextane-styles-->
         <link rel="preload" href="/client.js">
+        <SCRIPT>globalThis.__templateInline = true</SCRIPT >
       </head><body>
         <div id="__next"></div><!--nextane-data-->
-        <script type="module" src="/client.js"></script>
+        <SCRIPT data-note=">" type="module" src="/client.js"></SCRIPT >
       </body></html>`);
   },
 };
@@ -95,6 +96,7 @@ describe("Pages Router server compatibility", () => {
     expect(html).toContain('script id="__NEXT_DATA__"');
     expect(html).toMatch(/script[^>]+nonce="test-nonce"/);
     expect(html).toMatch(/link[^>]+nonce="test-nonce"/);
+    expect(html).not.toContain("__templateInline");
   });
 
   it("keeps the original data URL on req while exposing the resolved page URL", async () => {

--- a/test/unit/plugin-security.test.ts
+++ b/test/unit/plugin-security.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertNoUnsupportedRoutingFiles,
   createClientPageSource,
+  javascriptStringLiteral,
   loadRoutingConfig,
   nextane,
 } from "../../src/plugin";
@@ -24,6 +25,16 @@ async function filesBelow(directory: string): Promise<string[]> {
 }
 
 describe("client build security", () => {
+  it("encodes virtual-module strings without executable source characters", () => {
+    const value = "\";globalThis.pwned=true;//\n</script>\u2028😀";
+    const literal = javascriptStringLiteral(value);
+
+    expect(literal).toMatch(/^"(?:\\u[0-9a-f]{4})*"$/);
+    expect(JSON.parse(literal)).toBe(value);
+    expect(literal).not.toContain("globalThis");
+    expect(literal).not.toContain("</script>");
+  });
+
   it("removes server exports, dependency branches, and static initializers", async () => {
     const transformed = await createClientPageSource(
       `


### PR DESCRIPTION
Removes DOM navigation sinks before router initialization, replaces polynomial route regexes with bounded string operations, replaces script-tag regex parsing with a quote-aware scanner, and emits virtual-module values through all-escaped JavaScript literals. Adds regression cases for generated-code injection and non-canonical script tags.