### PR TITLE
Harden cross-request isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The Next.js Pages Router, rebuilt on [Octane](https://octanejs.dev/).
 > idea, talk to an agent for a few hours, and end up with something real enough
 > to test.
 >
-> If you need a Next.js alternative, use
+> If you need a Next.js alternative, start with
 > [Vinext](https://vinext.dev/). It passes
 > [more than 97% of the supported Next.js deploy test suite](https://vinext.dev/compatibility),
-> runs real applications in production, and is much more mature. Nextane is
-> newer, narrower, and built on alpha software.
+> supports substantial Next.js applications today, and is much more mature.
+> Nextane is newer, narrower, and built on alpha software.
 
 [Vinext](https://github.com/cloudflare/vinext) reimplements the Next.js API on
 Vite. It began as a slop fork of Next.js. Nextane is me doing it again, this
@@ -40,9 +40,9 @@ builds ship:
 | --- | ---: | ---: |
 | Next.js 16.2.12 | 109.9 KiB | — |
 | Vinext 1.0.0-beta.4 | 77.8 KiB | 29.2% less |
-| Nextane + Octane 0.1.19 | **40.8 KiB** | **62.9% less** |
+| Nextane + Octane 0.1.19 | **41.0 KiB** | **62.7% less** |
 
-Nextane ships 47.6% less client JavaScript than Vinext in this fixture. Its
+Nextane ships 47.3% less client JavaScript than Vinext in this fixture. Its
 production build is slower than Vinext's, and its measured SSR throughput
 trails both Vinext and Next.js. See the
 [full methodology and results](./docs/benchmark.md).
@@ -51,8 +51,8 @@ trails both Vinext and Next.js. See the
 
 Probably not.
 
-Use Vinext if you need a production-ready alternative to Next.js. Try Nextane
-if:
+Start with Vinext if you need a more mature alternative to Next.js. Try
+Nextane if:
 
 - you have an existing Pages Router application;
 - you want to see how far Octane can replace React while keeping the same APIs;
@@ -123,8 +123,8 @@ Then open `http://127.0.0.1:5173`.
 npm run check
 ```
 
-The check runs typechecking, 21 low-level routing/API contract tests, five
-real-browser Pages Router flows, and a production build.
+The check runs typechecking, 56 unit and security tests, release-workflow
+checks, six real-browser Pages Router flows, and a production build.
 
 See [architecture](./docs/architecture.md) for implementation details. Nextane
 is not affiliated with Vercel, Next.js, Vinext, Cloudflare, or Octane.

--- a/benchmarks/pages-compare/results/latest.json
+++ b/benchmarks/pages-compare/results/latest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-30T03:15:23.035Z",
+  "generatedAt": "2026-07-30T18:03:22.433Z",
   "methodology": {
     "buildRuns": 7,
     "buildMeasurementsReused": false,
@@ -22,25 +22,25 @@
     "vinext": "1.0.0-beta.4",
     "vinextCommit": "npm package",
     "octane": "0.1.19",
-    "nextaneCommit": "0.1.0"
+    "nextaneCommit": "678940d+dirty"
   },
   "projects": {
     "nextjs": {
       "build": {
         "runs": [
-          1095.9,
-          1159.6,
-          1332.8,
-          1389.3,
-          1111.5,
-          1098.7,
-          1103.5
+          1129.9,
+          1159.4,
+          1116.9,
+          1503.9,
+          1120.6,
+          1092.7,
+          1082.5
         ],
-        "mean": 1184.5,
-        "median": 1111.5,
-        "min": 1095.9,
-        "max": 1389.3,
-        "stddev": 123.6
+        "mean": 1172.3,
+        "median": 1120.6,
+        "min": 1082.5,
+        "max": 1503.9,
+        "stddev": 148.3
       },
       "artifacts": {
         "client": {
@@ -48,9 +48,9 @@
           "gzip": 128236,
           "files": 16,
           "fileNames": [
-            "Qv2t1YJIi3hYstdOwKcfr/_buildManifest.js",
-            "Qv2t1YJIi3hYstdOwKcfr/_clientMiddlewareManifest.js",
-            "Qv2t1YJIi3hYstdOwKcfr/_ssgManifest.js",
+            "OcpgrIr0CRFECQroaO2Jh/_buildManifest.js",
+            "OcpgrIr0CRFECQroaO2Jh/_clientMiddlewareManifest.js",
+            "OcpgrIr0CRFECQroaO2Jh/_ssgManifest.js",
             "chunks/0xce80o9ye3o4.js",
             "chunks/10dejet16_g7b.js",
             "chunks/1646pv3p7z828.js",
@@ -110,7 +110,7 @@
               "gzip": 6188
             },
             {
-              "url": "/_next/static/Qv2t1YJIi3hYstdOwKcfr/_buildManifest.js",
+              "url": "/_next/static/OcpgrIr0CRFECQroaO2Jh/_buildManifest.js",
               "raw": 336,
               "gzip": 211
             },
@@ -125,12 +125,12 @@
               "gzip": 4130
             },
             {
-              "url": "/_next/static/Qv2t1YJIi3hYstdOwKcfr/_ssgManifest.js",
+              "url": "/_next/static/OcpgrIr0CRFECQroaO2Jh/_ssgManifest.js",
               "raw": 76,
               "gzip": 60
             },
             {
-              "url": "/_next/static/Qv2t1YJIi3hYstdOwKcfr/_clientMiddlewareManifest.js",
+              "url": "/_next/static/OcpgrIr0CRFECQroaO2Jh/_clientMiddlewareManifest.js",
               "raw": 96,
               "gzip": 66
             },
@@ -150,16 +150,16 @@
               "decodedBodySize": 14478
             },
             {
-              "name": "http://127.0.0.1:4211/_next/static/chunks/3jcdn7fen80as.js",
-              "transferSize": 92718,
-              "encodedBodySize": 92418,
-              "decodedBodySize": 309404
-            },
-            {
               "name": "http://127.0.0.1:4211/_next/static/chunks/turbopack-3uaj2zcmbw_rb.js",
               "transferSize": 4431,
               "encodedBodySize": 4131,
               "decodedBodySize": 10516
+            },
+            {
+              "name": "http://127.0.0.1:4211/_next/static/chunks/3jcdn7fen80as.js",
+              "transferSize": 92718,
+              "encodedBodySize": 92418,
+              "decodedBodySize": 309404
             },
             {
               "name": "http://127.0.0.1:4211/_next/static/chunks/1hcdqbss0mrr0.js",
@@ -168,7 +168,7 @@
               "decodedBodySize": 16957
             },
             {
-              "name": "http://127.0.0.1:4211/_next/static/Qv2t1YJIi3hYstdOwKcfr/_buildManifest.js",
+              "name": "http://127.0.0.1:4211/_next/static/OcpgrIr0CRFECQroaO2Jh/_buildManifest.js",
               "transferSize": 636,
               "encodedBodySize": 336,
               "decodedBodySize": 336
@@ -180,70 +180,70 @@
               "decodedBodySize": 10517
             },
             {
-              "name": "http://127.0.0.1:4211/_next/static/Qv2t1YJIi3hYstdOwKcfr/_ssgManifest.js",
+              "name": "http://127.0.0.1:4211/_next/static/OcpgrIr0CRFECQroaO2Jh/_ssgManifest.js",
               "transferSize": 376,
               "encodedBodySize": 76,
               "decodedBodySize": 76
             },
             {
-              "name": "http://127.0.0.1:4211/_next/static/Qv2t1YJIi3hYstdOwKcfr/_clientMiddlewareManifest.js",
+              "name": "http://127.0.0.1:4211/_next/static/OcpgrIr0CRFECQroaO2Jh/_clientMiddlewareManifest.js",
               "transferSize": 396,
               "encodedBodySize": 96,
               "decodedBodySize": 96
             }
           ],
           "navigation": {
-            "transferSize": 1024,
-            "encodedBodySize": 724,
+            "transferSize": 1025,
+            "encodedBodySize": 725,
             "decodedBodySize": 2229
           }
         },
         "html": {
           "raw": 2229,
-          "gzip": 724
+          "gzip": 725
         }
       },
       "requests": {
-        "requestsPerSecond": 4163.5,
-        "meanLatency": 3.8,
-        "p50Latency": 3.5,
-        "p95Latency": 5.8,
-        "p99Latency": 9.1,
+        "requestsPerSecond": 3058.4,
+        "meanLatency": 5.2,
+        "p50Latency": 4.3,
+        "p95Latency": 10.4,
+        "p99Latency": 13.7,
         "rounds": [
           {
-            "requestsPerSecond": 3846.86958583168,
-            "meanLatency": 4.13219913799996,
-            "p50Latency": 3.827665999997407,
-            "p95Latency": 5.650125000000116,
-            "p99Latency": 9.0625
+            "requestsPerSecond": 1887.0459863596207,
+            "meanLatency": 8.467018672999977,
+            "p50Latency": 5.298500000004424,
+            "p95Latency": 17.488917000002402,
+            "p99Latency": 111.20149999999558
           },
           {
-            "requestsPerSecond": 4008.936577095903,
-            "meanLatency": 3.973495273000059,
-            "p50Latency": 3.692750000001979,
-            "p95Latency": 5.973625000005995,
-            "p99Latency": 9.439832999996725
+            "requestsPerSecond": 3058.3662468082857,
+            "meanLatency": 5.21697489100002,
+            "p50Latency": 4.322290999996767,
+            "p95Latency": 10.403958000002604,
+            "p99Latency": 20.254582999994454
           },
           {
-            "requestsPerSecond": 4606.13070746175,
-            "meanLatency": 3.4584283249999426,
-            "p50Latency": 3.325749999996333,
-            "p95Latency": 4.817332999999053,
-            "p99Latency": 5.310457999999926
+            "requestsPerSecond": 2817.7275423543274,
+            "meanLatency": 5.673141749000017,
+            "p50Latency": 4.980790999994497,
+            "p95Latency": 11.175125000001572,
+            "p99Latency": 13.71004200000607
           },
           {
-            "requestsPerSecond": 4302.942190509473,
-            "meanLatency": 3.710356015999969,
-            "p50Latency": 3.51337500000227,
-            "p95Latency": 5.7913750000006985,
-            "p99Latency": 8.46454200000153
+            "requestsPerSecond": 4012.2406722345872,
+            "meanLatency": 3.979960925999927,
+            "p50Latency": 3.662625000004482,
+            "p95Latency": 6.593709000000672,
+            "p99Latency": 7.324458999995841
           },
           {
-            "requestsPerSecond": 4163.537508008242,
-            "meanLatency": 3.8291875190000066,
-            "p50Latency": 3.4339169999948354,
-            "p95Latency": 6.140292000003683,
-            "p99Latency": 14.169958000005863
+            "requestsPerSecond": 3751.26369757997,
+            "meanLatency": 4.2518090719999675,
+            "p50Latency": 3.8092499999984284,
+            "p95Latency": 7.940416999997979,
+            "p99Latency": 11.638875000004191
           }
         ]
       }
@@ -251,19 +251,19 @@
     "vinext": {
       "build": {
         "runs": [
-          472.7,
-          544.2,
-          528.5,
-          507.5,
-          484.1,
-          470.7,
-          575
+          463.1,
+          468.8,
+          465.2,
+          619.7,
+          541.1,
+          464.9,
+          471
         ],
-        "mean": 511.8,
-        "median": 507.5,
-        "min": 470.7,
-        "max": 575,
-        "stddev": 39.4
+        "mean": 499.1,
+        "median": 468.8,
+        "min": 463.1,
+        "max": 619.7,
+        "stddev": 60
       },
       "artifacts": {
         "client": {
@@ -271,8 +271,8 @@
           "gzip": 94273,
           "files": 10,
           "fileNames": [
-            "_next/static/30126164-177c-4021-a5be-10e507c24989/_buildManifest.js",
-            "_next/static/30126164-177c-4021-a5be-10e507c24989/_ssgManifest.js",
+            "_next/static/9559fc10-7930-4b91-9d7f-5f3dc1b0f9b9/_buildManifest.js",
+            "_next/static/9559fc10-7930-4b91-9d7f-5f3dc1b0f9b9/_ssgManifest.js",
             "_next/static/chunks/config-matchers-MYSnu83e.js",
             "_next/static/chunks/error-Drph6Ses.js",
             "_next/static/chunks/framework-ttvUFOyE.js",
@@ -284,8 +284,8 @@
           ]
         },
         "server": {
-          "raw": 156087,
-          "gzip": 49609,
+          "raw": 156101,
+          "gzip": 49631,
           "files": 2,
           "fileNames": [
             "_next/static/chunks/hybrid-client-route-owner-CKwPeHTy.js",
@@ -370,50 +370,50 @@
         },
         "html": {
           "raw": 2272,
-          "gzip": 775
+          "gzip": 776
         }
       },
       "requests": {
-        "requestsPerSecond": 3186.9,
-        "meanLatency": 5,
-        "p50Latency": 4.1,
-        "p95Latency": 8.7,
-        "p99Latency": 9.7,
+        "requestsPerSecond": 2615.7,
+        "meanLatency": 6.1,
+        "p50Latency": 4.2,
+        "p95Latency": 13.8,
+        "p99Latency": 21.3,
         "rounds": [
           {
-            "requestsPerSecond": 1720.896414942547,
-            "meanLatency": 9.280254285999945,
-            "p50Latency": 7.819667000003392,
-            "p95Latency": 20.72733299999527,
-            "p99Latency": 28.911332999996375
+            "requestsPerSecond": 2615.667545704451,
+            "meanLatency": 6.100639895000175,
+            "p50Latency": 4.397125000003143,
+            "p95Latency": 13.838999999999942,
+            "p99Latency": 21.311249999998836
           },
           {
-            "requestsPerSecond": 3181.030461799016,
-            "meanLatency": 5.014939600999991,
-            "p50Latency": 4.107499999998254,
-            "p95Latency": 8.696708000003127,
-            "p99Latency": 9.606500000001688
+            "requestsPerSecond": 1997.9131796838421,
+            "meanLatency": 7.999062617999938,
+            "p50Latency": 5.153749999997672,
+            "p95Latency": 20.088207999993756,
+            "p99Latency": 42.520958000000974
           },
           {
-            "requestsPerSecond": 3406.81309063019,
-            "meanLatency": 4.689669985000088,
-            "p50Latency": 3.855834000001778,
-            "p95Latency": 8.45908299999428,
-            "p99Latency": 9.73554200000217
+            "requestsPerSecond": 2450.682814392176,
+            "meanLatency": 6.519683358999944,
+            "p50Latency": 4.229790999997931,
+            "p95Latency": 14.292166999999608,
+            "p99Latency": 55.18433299999742
           },
           {
-            "requestsPerSecond": 3738.378898720261,
-            "meanLatency": 4.274439656999937,
-            "p50Latency": 3.9194579999966663,
-            "p95Latency": 6.606958999997005,
-            "p99Latency": 15.192791000001307
+            "requestsPerSecond": 3790.2902020910883,
+            "meanLatency": 4.214763893999894,
+            "p50Latency": 4.015625,
+            "p95Latency": 5.787917000001471,
+            "p99Latency": 7.178915999997116
           },
           {
-            "requestsPerSecond": 3186.851052557146,
-            "meanLatency": 5.0049271869998115,
-            "p50Latency": 4.072041999999783,
-            "p95Latency": 8.981291999996756,
-            "p99Latency": 9.579124999996566
+            "requestsPerSecond": 3282.187282426915,
+            "meanLatency": 4.855168460000059,
+            "p50Latency": 3.863791999996465,
+            "p95Latency": 9.306416999999783,
+            "p99Latency": 10.345208999999159
           }
         ]
       }
@@ -421,34 +421,34 @@
     "nextane": {
       "build": {
         "runs": [
-          1220.1,
-          1249.4,
-          1202.9,
-          1195.3,
-          1245.1,
-          1144.8,
-          1238.9
+          1183.6,
+          1187.3,
+          1187.8,
+          1481.7,
+          1242.7,
+          1378.3,
+          1142.4
         ],
-        "mean": 1213.8,
-        "median": 1220.1,
-        "min": 1144.8,
-        "max": 1249.4,
-        "stddev": 36.8
+        "mean": 1257.7,
+        "median": 1187.8,
+        "min": 1142.4,
+        "max": 1481.7,
+        "stddev": 124.9
       },
       "artifacts": {
         "client": {
-          "raw": 127365,
-          "gzip": 41775,
+          "raw": 127843,
+          "gzip": 42024,
           "files": 3,
           "fileNames": [
-            "assets/index-Ctb4x9tA.js",
-            "assets/pages-BkpsIQ6H.js",
+            "assets/index-DrC6HNjV.js",
+            "assets/pages-B4OAMHLA.js",
             "assets/runtime-DEv-0lHW.js"
           ]
         },
         "server": {
-          "raw": 125613,
-          "gzip": 32090,
+          "raw": 139374,
+          "gzip": 35256,
           "files": 3,
           "fileNames": [
             "assets/pages-DaBLCYqt.js",
@@ -463,13 +463,13 @@
         "hydration": "Count: 0 → Count: 1",
         "requestedJs": {
           "files": 3,
-          "raw": 127365,
-          "gzip": 41775,
+          "raw": 127843,
+          "gzip": 42024,
           "urls": [
             {
-              "url": "/assets/index-Ctb4x9tA.js",
-              "raw": 10425,
-              "gzip": 4113
+              "url": "/assets/index-DrC6HNjV.js",
+              "raw": 11046,
+              "gzip": 4451
             },
             {
               "url": "/assets/runtime-DEv-0lHW.js",
@@ -477,19 +477,19 @@
               "gzip": 37209
             },
             {
-              "url": "/assets/pages-BkpsIQ6H.js",
-              "raw": 728,
-              "gzip": 453
+              "url": "/assets/pages-B4OAMHLA.js",
+              "raw": 585,
+              "gzip": 364
             }
           ]
         },
         "resourceTiming": {
           "resources": [
             {
-              "name": "http://127.0.0.1:4213/assets/index-Ctb4x9tA.js",
-              "transferSize": 4400,
-              "encodedBodySize": 4100,
-              "decodedBodySize": 10425
+              "name": "http://127.0.0.1:4213/assets/index-DrC6HNjV.js",
+              "transferSize": 4759,
+              "encodedBodySize": 4459,
+              "decodedBodySize": 11046
             },
             {
               "name": "http://127.0.0.1:4213/assets/runtime-DEv-0lHW.js",
@@ -498,64 +498,64 @@
               "decodedBodySize": 116212
             },
             {
-              "name": "http://127.0.0.1:4213/assets/pages-BkpsIQ6H.js",
-              "transferSize": 751,
-              "encodedBodySize": 451,
-              "decodedBodySize": 728
+              "name": "http://127.0.0.1:4213/assets/pages-B4OAMHLA.js",
+              "transferSize": 664,
+              "encodedBodySize": 364,
+              "decodedBodySize": 585
             }
           ],
           "navigation": {
-            "transferSize": 983,
-            "encodedBodySize": 683,
+            "transferSize": 984,
+            "encodedBodySize": 684,
             "decodedBodySize": 1815
           }
         },
         "html": {
           "raw": 1815,
-          "gzip": 684
+          "gzip": 685
         }
       },
       "requests": {
-        "requestsPerSecond": 1744.6,
-        "meanLatency": 9.1,
-        "p50Latency": 7,
-        "p95Latency": 18.7,
-        "p99Latency": 38.9,
+        "requestsPerSecond": 1631.8,
+        "meanLatency": 9.8,
+        "p50Latency": 8,
+        "p95Latency": 21.8,
+        "p99Latency": 42.9,
         "rounds": [
           {
-            "requestsPerSecond": 1435.7030269824184,
-            "meanLatency": 11.114208703000033,
-            "p50Latency": 8.193874999997206,
-            "p95Latency": 23.444584000004397,
-            "p99Latency": 68.1909169999999
+            "requestsPerSecond": 1631.805412243593,
+            "meanLatency": 9.775556251000031,
+            "p50Latency": 7.954499999999825,
+            "p95Latency": 21.794833000007202,
+            "p99Latency": 42.917084000000614
           },
           {
-            "requestsPerSecond": 2063.5148125964743,
-            "meanLatency": 7.711600460999937,
-            "p50Latency": 6.597625000002154,
-            "p95Latency": 15.323874999994587,
-            "p99Latency": 22.254124999999476
+            "requestsPerSecond": 1580.864477781056,
+            "meanLatency": 10.08576871299991,
+            "p50Latency": 8.12050000000454,
+            "p95Latency": 22.79541700000118,
+            "p99Latency": 33.180208999998285
           },
           {
-            "requestsPerSecond": 2099.9194155924033,
-            "meanLatency": 7.590759625000028,
-            "p50Latency": 6.500374999995984,
-            "p95Latency": 16.035416999999143,
-            "p99Latency": 22.22479200000089
+            "requestsPerSecond": 1923.1129814453427,
+            "meanLatency": 8.29024287700007,
+            "p50Latency": 7.110584000001836,
+            "p95Latency": 16.557041000000027,
+            "p99Latency": 18.45220800000243
           },
           {
-            "requestsPerSecond": 1657.7971067710305,
-            "meanLatency": 9.61316549199989,
-            "p50Latency": 7.6162919999987935,
-            "p95Latency": 18.671166000000085,
-            "p99Latency": 49.95487499999581
+            "requestsPerSecond": 1727.6950973643739,
+            "meanLatency": 9.231256628999922,
+            "p50Latency": 7.236665999997058,
+            "p95Latency": 17.15758300000016,
+            "p99Latency": 66.31750000000466
           },
           {
-            "requestsPerSecond": 1744.6346296048448,
-            "meanLatency": 9.139955725000043,
-            "p50Latency": 6.987958999998227,
-            "p95Latency": 21.129208000005747,
-            "p99Latency": 38.856041999999434
+            "requestsPerSecond": 1324.8608482090376,
+            "meanLatency": 12.046817569999869,
+            "p50Latency": 8.990165999995952,
+            "p95Latency": 31.992167000003974,
+            "p99Latency": 69.24133299999812
           }
         ]
       }

--- a/benchmarks/pages-compare/results/latest.md
+++ b/benchmarks/pages-compare/results/latest.md
@@ -1,20 +1,20 @@
 # Pages rendering benchmark
 
-Generated 2026-07-30T03:15:23.035Z on Apple M4.
+Generated 2026-07-30T18:03:22.433Z on Apple M4.
 
 ## Results
 
 | Metric | Next.js | Vinext | Nextane |
 | --- | ---: | ---: | ---: |
-| Production build, median | 1111.5 ms | 507.5 ms | 1220.1 ms |
-| Cold-page JS, raw | 353.9 KiB | 247.3 KiB | 124.4 KiB |
-| Cold-page JS, gzip | 109.9 KiB | 77.8 KiB | 40.8 KiB |
+| Production build, median | 1120.6 ms | 468.8 ms | 1187.8 ms |
+| Cold-page JS, raw | 353.9 KiB | 247.3 KiB | 124.8 KiB |
+| Cold-page JS, gzip | 109.9 KiB | 77.8 KiB | 41.0 KiB |
 | SSR HTML, raw | 2.2 KiB | 2.2 KiB | 1.8 KiB |
 | SSR HTML, gzip | 0.7 KiB | 0.8 KiB | 0.7 KiB |
-| Local SSR requests/sec, median | 4163.5 | 3186.9 | 1744.6 |
-| Local SSR p50 | 3.5 ms | 4.1 ms | 7.0 ms |
-| Client artifact JS/CSS, gzip | 125.2 KiB | 92.1 KiB | 40.8 KiB |
-| Server artifact JS/CSS, gzip | 48.9 KiB | 48.4 KiB | 31.3 KiB |
+| Local SSR requests/sec, median | 3058.4 | 2615.7 | 1631.8 |
+| Local SSR p50 | 4.3 ms | 4.2 ms | 8.0 ms |
+| Client artifact JS/CSS, gzip | 125.2 KiB | 92.1 KiB | 41.0 KiB |
+| Server artifact JS/CSS, gzip | 48.9 KiB | 48.5 KiB | 34.4 KiB |
 
 All three produced the same normalized visible text and hydrated `Count: 0` to
 `Count: 1`. Browser JavaScript counts only unique `.js` responses requested
@@ -30,4 +30,4 @@ isolated renderer speed. Server artifact layouts are also not equivalent.
 - React 19.2.7
 - Vinext 1.0.0-beta.4 (npm package)
 - Octane 0.1.19
-- Nextane 0.1.0
+- Nextane source 678940d+dirty

--- a/benchmarks/pages-compare/run.mjs
+++ b/benchmarks/pages-compare/run.mjs
@@ -409,6 +409,21 @@ function gitHash(repository) {
   return result.status === 0 ? result.stdout.trim() : "uncommitted";
 }
 
+function gitRevision(repository) {
+  const revision = gitHash(repository);
+  const status = spawnSync(
+    "git",
+    ["status", "--porcelain", "--untracked-files=no"],
+    {
+      cwd: repository,
+      encoding: "utf8",
+    },
+  );
+  return status.status === 0 && status.stdout.trim()
+    ? `${revision}+dirty`
+    : revision;
+}
+
 function formatBytes(bytes) {
   return `${(bytes / 1024).toFixed(1)} KiB`;
 }
@@ -455,7 +470,7 @@ function markdown(results) {
     `- React ${results.versions.react}`,
     `- Vinext ${results.versions.vinext} (${results.versions.vinextCommit})`,
     `- Octane ${results.versions.octane}`,
-    `- Nextane ${results.versions.nextaneCommit}`,
+    `- Nextane source ${results.versions.nextaneCommit}`,
     "",
   );
   return lines.join("\n");
@@ -561,7 +576,7 @@ async function main() {
         vinext: readVersion(vinextPackagePath),
         vinextCommit: vinextRepository ? gitHash(vinextRepository) : "npm package",
         octane: readVersion(path.join(projectRoot, "node_modules/octane/package.json")),
-        nextaneCommit: readVersion(path.join(projectRoot, "package.json")),
+        nextaneCommit: gitRevision(projectRoot),
       },
       projects: Object.fromEntries(
         Object.keys(projects).map((key) => [
@@ -585,7 +600,7 @@ async function main() {
       path.join(resultsDirectory, "latest.json"),
       `${JSON.stringify(results, null, 2)}\n`,
     );
-    writeFileSync(path.join(resultsDirectory, "latest.md"), `${markdown(results)}\n`);
+    writeFileSync(path.join(resultsDirectory, "latest.md"), markdown(results));
     console.log(`Wrote ${path.join(resultsDirectory, "latest.md")}`);
   } finally {
     for (const server of Object.values(servers)) stopServer(server);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,8 +77,34 @@ Production verification on July 29, 2026 observed `MISS`, then `UPDATING`
 during stale-while-revalidate, then `HIT`. The final HTML and page-data
 responses carried the identical generation timestamp.
 
-Local workerd does not yet emulate this new cache layer, so development uses a
-small in-memory substitute with the same artifact boundary.
+Local workerd does not yet emulate this new front-of-Worker cache layer, so
+development uses the standard Workers Cache API with the same artifact
+boundary. Nextane does not keep rendered application responses in a
+process-global `Map`.
+
+## Cross-request isolation
+
+GSSP, API, page `getInitialProps`, and request-dependent `_app` or `_document`
+responses are rendered per request and are private/no-store by default. Router
+state is carried through `AsyncLocalStorage`, including across suspended Octane
+render passes.
+
+Only `getStaticProps` artifacts are eligible for sharing. Before generating
+one, Nextane replaces the incoming request with a synthetic canonical request:
+the origin is fixed, the URL contains only the matched pathname, and all
+incoming headers and query parameters are removed. Routes using
+`_app.getInitialProps` or `_document.getInitialProps` bypass the shared cache
+entirely.
+
+Every artifact read from the cache is checked against the current build ID,
+route, pathname, and dynamic params. Nextane also rejects cached artifacts that
+contain App props, response headers or cookies, fallback state, request
+response bodies, or non-static markers. A collision or malformed cache entry
+therefore fails closed instead of being rendered to another request.
+
+Application modules still run in a long-lived Worker isolate. As with any
+server framework, application code must not put request-specific values in
+module-level variables or its own shared caches.
 
 ## Intentional boundaries
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -5,7 +5,7 @@ page through:
 
 - Next.js 16.2.12 and React 19.2.7;
 - Vinext 1.0.0-beta.4 from npm and React 19.2.7; and
-- Nextane 0.1.0 and Octane 0.1.19.
+- the current local Nextane checkout and Octane 0.1.19.
 
 The page uses `getServerSideProps`, renders a heading, deterministic timestamp,
 hydrated counter, and 20 deterministic rows. The normalized visible content
@@ -16,23 +16,23 @@ matched across all three, and every counter hydrated from `Count: 0` to
 
 | Metric | Next.js | Vinext | Nextane |
 | --- | ---: | ---: | ---: |
-| Production build, median of 7 | 1,111.5 ms | **507.5 ms** | 1,220.1 ms |
-| Cold-page JavaScript, raw | 353.9 KiB | 247.3 KiB | **124.4 KiB** |
-| Cold-page JavaScript, gzip | 109.9 KiB | 77.8 KiB | **40.8 KiB** |
+| Production build, median of 7 | 1,120.6 ms | **468.8 ms** | 1,187.8 ms |
+| Cold-page JavaScript, raw | 353.9 KiB | 247.3 KiB | **124.8 KiB** |
+| Cold-page JavaScript, gzip | 109.9 KiB | 77.8 KiB | **41.0 KiB** |
 | SSR HTML, raw | 2.2 KiB | 2.2 KiB | **1.8 KiB** |
 | SSR HTML, gzip | 0.7 KiB | 0.8 KiB | **0.7 KiB** |
-| Local SSR requests/sec, median | **4,163.5** | 3,186.9 | 1,744.6 |
-| Local SSR p50 | **3.5 ms** | 4.1 ms | 7.0 ms |
+| Local SSR requests/sec, median | **3,058.4** | 2,615.7 | 1,631.8 |
+| Local SSR p50 | 4.3 ms | **4.2 ms** | 8.0 ms |
 
 For this deliberately small hydrated page, Nextane requested:
 
-- **62.9% less gzipped JavaScript than Next.js**; and
-- **47.6% less gzipped JavaScript than Vinext**.
+- **62.7% less gzipped JavaScript than Next.js**; and
+- **47.3% less gzipped JavaScript than Vinext**.
 
-The compatibility work since the first measurement added 1.5 KiB of requested
-gzipped client JavaScript, a 3.7% increase. Nextane's median build was 9.8%
-slower than Next.js and 140.4% slower than Vinext. Its sustained local SSR
-throughput was 58.1% below Next.js and 45.3% below Vinext.
+The compatibility and security work since the first measurement added 1.7 KiB
+of requested gzipped client JavaScript, a 4.3% increase. Nextane's median build
+was 6.0% slower than Next.js and 153.4% slower than Vinext. Its sustained local
+SSR throughput was 46.6% below Next.js and 37.6% below Vinext.
 
 ## What the numbers mean
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,13 +41,13 @@ larger Next.js Pages Router compatibility claim.
 
 The prototype-owned suite currently has:
 
-- **21/21 unit tests** covering route discovery/matching, classic and Edge API
-  request/response adaptation, URL normalization, and the expanded Pages
-  server contract;
-- **5/5 browser flows locally** covering SSR, hydration, state, duplicate-free
+- **56/56 unit and security tests** covering route discovery/matching, classic
+  and Edge API request/response adaptation, URL normalization, cache isolation,
+  and the expanded Pages server contract;
+- **6/6 browser flows locally** covering SSR, hydration, state, duplicate-free
   links, soft navigation, browser back, dynamic params, API routes, custom
-  404s, and shared ISR artifacts; and
-- **5/5 of those browser flows against the deployed Worker**.
+  404s, shared ISR artifacts, and public security boundaries; and
+- **6/6 of those browser flows against the deployed Worker**.
 
 These are prototype-owned tests, not upstream Next.js tests.
 

--- a/scripts/test-package-install.mjs
+++ b/scripts/test-package-install.mjs
@@ -260,6 +260,29 @@ export default function Post({ slug, generatedAt }) {
   );
 }
 `,
+    "pages/isolation.tsrx": `export async function getServerSideProps({
+  req,
+  res,
+  query,
+}) {
+  const token = String(query.token);
+  await new Promise((resolve) => setTimeout(resolve, Number(query.delay) % 5));
+  res.setHeader("x-request-canary", token);
+  res.setHeader("set-cookie", \`request-canary=\${token}; Path=/; HttpOnly\`);
+  return {
+    props: {
+      token,
+      authorization: req.headers.get("authorization"),
+      cookie: req.cookies.session,
+      requestUrl: req.url,
+    },
+  };
+}
+
+export default function Isolation(props) {
+  return <pre id="request-isolation">{JSON.stringify(props)}</pre>;
+}
+`,
     "pages/api/hello.ts": `import type {
   NextApiRequest,
   NextApiResponse,
@@ -321,6 +344,45 @@ export default function handler(
   const api = await fetch(`${origin}/api/hello?name=package`);
   assert.equal(api.status, 200);
   assert.deepEqual(await api.json(), { hello: "package" });
+  assert.equal(api.headers.get("cache-control"), "private, no-store");
+
+  const isolationTokens = Array.from(
+    { length: 16 },
+    (_, index) => `package-${String(index).padStart(2, "0")}-canary`,
+  );
+  const isolationResponses = await Promise.all(
+    isolationTokens.map((token, index) =>
+      fetch(
+        `${origin}/isolation?token=${encodeURIComponent(token)}&delay=${index}`,
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            cookie: `session=${token}`,
+          },
+        },
+      ),
+    ),
+  );
+  const isolationBodies = await Promise.all(
+    isolationResponses.map((response) => response.text()),
+  );
+  for (let index = 0; index < isolationTokens.length; index += 1) {
+    const token = isolationTokens[index];
+    const response = isolationResponses[index];
+    const body = isolationBodies[index];
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("cache-control"),
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    assert.equal(response.headers.get("x-request-canary"), token);
+    assert.match(response.headers.get("set-cookie") ?? "", new RegExp(token));
+    assert.match(body, new RegExp(token));
+    assert.match(body, new RegExp(`Bearer ${token}`));
+    for (const other of isolationTokens) {
+      if (other !== token) assert.doesNotMatch(body, new RegExp(other));
+    }
+  }
 
   browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
@@ -381,6 +443,7 @@ export default function handler(
       runtime: {
         home: home.status,
         api: api.status,
+        concurrentRequestIsolation: true,
         installedHydration: true,
         fallbackShell: true,
         sharedIsrArtifact: true,

--- a/scripts/upstream/README.md
+++ b/scripts/upstream/README.md
@@ -66,22 +66,24 @@ it never deploys or publishes anything.
 
 Against the local Next.js `v16.2.2` baseline:
 
-- **252/252 substantive upstream deploy test cases passed** across server
+- **251/252 substantive upstream deploy test cases passed** across server
   rendering/data, async modules, modern and legacy Link, Head, router rewrites
   and events, `withRouter`, classic and Edge API routes, custom error handling,
-  both trailing-slash configurations, and all 63 prerendering/revalidation
-  deploy cases.
+  both trailing-slash configurations, and prerendering/revalidation. The one
+  expected failure asks Nextane to mint Preview Mode cookies; Nextane fails
+  closed until those cookies can be signed and validated.
 - **6 additional deploy-mode skip sentinels passed but are excluded from the
   substantive denominator**:
   - `404-page-router`: five `should skip for deploy` cases;
   - `api-resolver-query-writeable`: one `should skip next deploy` case.
 - **2 production-only routes-manifest assertions are skipped** in deploy mode.
 
-The full runner therefore has 258 passing test cases, but **258 must not be
-described as substantive compatibility coverage**. The honest smoke result is
-252/252 with six sentinels and two production-only skips reported separately.
-Nextane's own upstream conformance test covers writable API `req.query`
-because that upstream suite skips deploy mode.
+The full runner therefore has 257 passing test cases, one expected failure, and
+two pending tests, but **257 must not be described as substantive compatibility
+coverage**. The honest smoke result is 251/252 with six sentinels, one expected
+Preview Mode failure, and two production-only skips reported separately.
+Nextane's own upstream conformance test covers writable API `req.query` because
+that upstream suite skips deploy mode.
 
 Run the harness unit/conformance tests with:
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -292,6 +292,19 @@ class ApiResponse<Data = unknown> implements NextApiResponse<Data> {
   }
 }
 
+function withDefaultApiCachePolicy(response: Response): Response {
+  if (response.status === 101 || response.headers.has("cache-control")) {
+    return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", "private, no-store");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export async function runApiRoute(
   module: Record<string, unknown>,
   request: Request,
@@ -322,9 +335,11 @@ export async function runApiRoute(
       configurable: true,
     });
     const returned = await handler(request);
-    return returned instanceof Response
-      ? returned
-      : new Response(null, { status: 204 });
+    return withDefaultApiCachePolicy(
+      returned instanceof Response
+        ? returned
+        : new Response(null, { status: 204 }),
+    );
   }
 
   const pageRequest = createPageRequest(request);
@@ -358,5 +373,7 @@ export async function runApiRoute(
   };
   const apiResponse = new ApiResponse(options);
   const returned = await handler(apiRequest, apiResponse);
-  return returned instanceof Response ? returned : apiResponse.toResponse();
+  return withDefaultApiCachePolicy(
+    returned instanceof Response ? returned : apiResponse.toResponse(),
+  );
 }

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -958,6 +958,30 @@ function artifactData(artifact: RenderArtifact) {
   };
 }
 
+function defaultArtifactCacheControl(artifact: RenderArtifact): string {
+  if (artifact.gssp) {
+    return "private, no-cache, no-store, max-age=0, must-revalidate";
+  }
+  if (artifact.gsp && artifact.cacheable) {
+    return "public, max-age=0, must-revalidate";
+  }
+  return "private, no-store";
+}
+
+function applyArtifactCachePolicy(
+  headers: Headers,
+  artifact: RenderArtifact,
+): void {
+  if (!headers.has("cache-control")) {
+    headers.set("cache-control", defaultArtifactCacheControl(artifact));
+  }
+  // Request-dependent App/Document data must never be made public, even if
+  // application code tried to set a conflicting header on the response.
+  if (artifact.gsp && !artifact.cacheable) {
+    headers.set("cache-control", "private, no-store");
+  }
+}
+
 async function renderArtifactResponse(
   artifact: RenderArtifact,
   request: Request,
@@ -967,9 +991,7 @@ async function renderArtifactResponse(
 ): Promise<Response> {
   if (artifact.response?.ended) {
     const headers = new Headers(artifact.response.headers);
-    if (artifact.gsp && !artifact.cacheable) {
-      headers.set("cache-control", "private, no-store");
-    }
+    applyArtifactCachePolicy(headers, artifact);
     return new Response(artifact.response.body ?? null, {
       status: artifact.response.status,
       statusText: artifact.response.statusMessage,
@@ -977,12 +999,22 @@ async function renderArtifactResponse(
     });
   }
   if (artifact.redirect) {
-    return Response.redirect(
-      new URL(artifact.redirect.destination, request.url),
-      redirectStatus(artifact.redirect),
+    const headers = new Headers(artifact.response?.headers);
+    headers.set(
+      "location",
+      new URL(artifact.redirect.destination, request.url).toString(),
     );
+    applyArtifactCachePolicy(headers, artifact);
+    return new Response(null, {
+      status: redirectStatus(artifact.redirect),
+      headers,
+    });
   }
-  if (artifact.notFound) return new Response("Not Found", { status: 404 });
+  if (artifact.notFound) {
+    const headers = new Headers(artifact.response?.headers);
+    applyArtifactCachePolicy(headers, artifact);
+    return new Response("Not Found", { status: 404, headers });
+  }
 
   const nextData: NextaneData = {
     props: {
@@ -1029,11 +1061,7 @@ async function renderArtifactResponse(
   const headers = new Headers({
     "content-type": "text/html; charset=utf-8",
     "x-powered-by": "Nextane",
-    "cache-control": artifact.gssp
-      ? "private, no-cache, no-store, max-age=0, must-revalidate"
-      : artifact.gsp && artifact.cacheable
-        ? "public, max-age=0, must-revalidate"
-        : "private, no-store",
+    "cache-control": defaultArtifactCacheControl(artifact),
     "x-nextane-generated-at": String(artifact.generatedAt),
   });
   for (const [name, value] of artifact.response?.headers ?? []) {
@@ -1226,6 +1254,59 @@ function canonicalStaticRequest(
   });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function validatedSharedArtifact(
+  response: Response,
+  manifest: NextaneManifest,
+  route: ServerRouteManifest,
+  params: ParsedUrlQuery,
+  pathname: string,
+): Promise<RenderArtifact> {
+  const value = (await response.json()) as unknown;
+  if (!isRecord(value)) {
+    throw new Error("Shared ISR cache returned an invalid artifact");
+  }
+
+  const artifact = value as unknown as RenderArtifact;
+  const snapshot = artifact.response;
+  const responseIsCanonical =
+    snapshot !== undefined &&
+    snapshot.status === 200 &&
+    snapshot.ended === false &&
+    snapshot.body === undefined &&
+    Array.isArray(snapshot.headers) &&
+    snapshot.headers.length === 0;
+  const queryIsCanonical =
+    isRecord(artifact.query) &&
+    paramsEqual(params, artifact.query as ParsedUrlQuery);
+  const identityMatches =
+    artifact.buildId === (manifest.buildId ?? BUILD_ID) &&
+    artifact.route === route.route &&
+    artifact.resolvedPath === pathname;
+  const safelyShareable =
+    artifact.gsp === true &&
+    artifact.gssp === false &&
+    artifact.cacheable === true &&
+    artifact.isFallback !== true &&
+    artifact.appProps === undefined &&
+    !hasSetCookie(snapshot);
+
+  if (
+    !identityMatches ||
+    !queryIsCanonical ||
+    !responseIsCanonical ||
+    !safelyShareable ||
+    typeof artifact.generatedAt !== "number" ||
+    !Number.isFinite(artifact.generatedAt)
+  ) {
+    throw new Error("Shared ISR cache returned a mismatched artifact");
+  }
+  return artifact;
+}
+
 async function loadArtifact(
   manifest: NextaneManifest,
   route: ServerRouteManifest,
@@ -1266,7 +1347,13 @@ async function loadArtifact(
           );
           if (response.ok) {
             return {
-              artifact: (await response.json()) as RenderArtifact,
+              artifact: await validatedSharedArtifact(
+                response,
+                manifest,
+                route,
+                params,
+                artifactPageUrl.pathname,
+              ),
               cacheStatus:
                 response.headers.get("cf-cache-status") ??
                 response.headers.get("x-cache-status"),
@@ -1305,7 +1392,13 @@ async function loadArtifact(
       throw new Error(`ISR artifact entrypoint failed (${response.status})`);
     }
     return {
-      artifact: (await response.json()) as RenderArtifact,
+      artifact: await validatedSharedArtifact(
+        response,
+        manifest,
+        route,
+        params,
+        artifactPageUrl.pathname,
+      ),
       cacheStatus: response.headers.get("cf-cache-status") ?? response.headers.get("x-cache-status"),
     };
   }
@@ -1506,9 +1599,7 @@ export function createNextaneHandler(
         );
         if (artifact.response?.ended) {
           const responseHeaders = new Headers(artifact.response.headers);
-          if (artifact.gsp && !artifact.cacheable) {
-            responseHeaders.set("cache-control", "private, no-store");
-          }
+          applyArtifactCachePolicy(responseHeaders, artifact);
           const location = responseHeaders.get("location");
           if (
             location &&
@@ -1521,10 +1612,7 @@ export function createNextaneHandler(
                 __N_REDIRECT_STATUS: artifact.response.status,
               },
               {
-                headers:
-                  artifact.gsp && !artifact.cacheable
-                    ? { "cache-control": "private, no-store" }
-                    : undefined,
+                headers: responseHeaders,
               },
             );
           }
@@ -1537,14 +1625,7 @@ export function createNextaneHandler(
         const headers = new Headers({
           ...(cacheStatus ? { "x-nextane-cache-status": cacheStatus } : {}),
           "x-nextane-generated-at": String(artifact.generatedAt),
-          ...(artifact.gssp
-            ? {
-                "cache-control":
-                  "private, no-cache, no-store, max-age=0, must-revalidate",
-              }
-            : artifact.gsp && artifact.cacheable
-              ? { "cache-control": "public, max-age=0, must-revalidate" }
-              : { "cache-control": "private, no-store" }),
+          "cache-control": defaultArtifactCacheControl(artifact),
         });
         for (const [name, value] of artifact.response?.headers ?? []) {
           if (name.toLowerCase() === "set-cookie") headers.append(name, value);

--- a/test/e2e/pages-router.spec.ts
+++ b/test/e2e/pages-router.spec.ts
@@ -200,6 +200,86 @@ test("security boundaries hold through the public runtime", async ({
   const victim = await request.get("/?cacheProbe=victim");
   expect(await victim.text()).not.toContain(attackerCanary);
 
+  const isolationTokens = Array.from(
+    { length: 16 },
+    (_, index) => `e2e-${String(index).padStart(2, "0")}-${Date.now()}`,
+  );
+  const gsspResponses = await Promise.all(
+    isolationTokens.flatMap((token, index) => [
+      request.get(`/ssr?isolation=${encodeURIComponent(token)}`, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          cookie: `session=${token}`,
+        },
+      }),
+      request.get(
+        `/_next/data/${encodeURIComponent(buildId)}/ssr.json?isolation=${encodeURIComponent(token)}`,
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+            cookie: `session=${token}`,
+            "x-isolation-index": String(index),
+          },
+        },
+      ),
+    ]),
+  );
+  const gsspBodies = await Promise.all(
+    gsspResponses.map((response) => response.text()),
+  );
+  for (let index = 0; index < gsspResponses.length; index += 1) {
+    const token = isolationTokens[Math.floor(index / 2)];
+    expect(gsspResponses[index].status()).toBe(200);
+    expect(gsspResponses[index].headers()["cache-control"]).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(gsspBodies[index]).toContain(token);
+    for (const other of isolationTokens) {
+      if (other !== token) expect(gsspBodies[index]).not.toContain(other);
+    }
+  }
+
+  const apiResponses = await Promise.all(
+    isolationTokens.map((token) =>
+      request.get(`/api/hello?name=${encodeURIComponent(token)}`),
+    ),
+  );
+  for (let index = 0; index < apiResponses.length; index += 1) {
+    expect(apiResponses[index].status()).toBe(200);
+    expect(apiResponses[index].headers()["cache-control"]).toBe(
+      "private, no-store",
+    );
+    const payload = (await apiResponses[index].json()) as {
+      query: { name: string };
+    };
+    expect(payload.query.name).toBe(isolationTokens[index]);
+  }
+
+  const staticResponses = await Promise.all(
+    isolationTokens.map((token) =>
+      request.get(`/?cacheProbe=${encodeURIComponent(token)}`, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          cookie: `session=${token}`,
+          "accept-language": token,
+          "user-agent": token,
+        },
+      }),
+    ),
+  );
+  const staticBodies = await Promise.all(
+    staticResponses.map((response) => response.text()),
+  );
+  for (let index = 0; index < staticResponses.length; index += 1) {
+    expect(staticResponses[index].status()).toBe(200);
+    expect(staticResponses[index].headers()["cache-control"]).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    for (const token of isolationTokens) {
+      expect(staticBodies[index]).not.toContain(token);
+    }
+  }
+
   if (process.env.NEXTANE_BASE_URL) {
     const scriptSources = [
       ...homeHtml.matchAll(/<script\b[^>]*\bsrc="([^"]+\.js)"/g),

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -38,12 +38,88 @@ describe("Pages Router API routes", () => {
 
     expect(response.status).toBe(201);
     expect(response.headers.get("x-api-shape")).toBe("next");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(await response.json()).toEqual({
       method: "POST",
       query: { name: "Steve" },
       cookies: { session: "octane powered" },
       body: { hello: "world" },
     });
+  });
+
+  it("isolates overlapping API request bodies, cookies, headers, query, and response state", async () => {
+    const requestCount = 24;
+    let entered = 0;
+    let releaseAll!: () => void;
+    const allEntered = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+    const route = {
+      async default(
+        request: {
+          body: { token: string };
+          cookies: Record<string, string>;
+          headers: { get(name: string): string | null };
+          query: Record<string, unknown>;
+        },
+        reply: {
+          setHeader(name: string, value: string): void;
+          json(value: unknown): void;
+        },
+      ) {
+        const token = request.body.token;
+        entered += 1;
+        if (entered === requestCount) releaseAll();
+        await allEntered;
+        reply.setHeader("x-request-canary", token);
+        reply.setHeader(
+          "set-cookie",
+          `api-canary=${token}; Path=/; HttpOnly`,
+        );
+        reply.json({
+          token,
+          cookie: request.cookies.session,
+          authorization: request.headers.get("authorization"),
+          query: request.query.token,
+        });
+      },
+    };
+    const tokens = Array.from(
+      { length: requestCount },
+      (_, index) => `api-${String(index).padStart(2, "0")}-canary`,
+    );
+    const responses = await Promise.all(
+      tokens.map((token) =>
+        runApiRoute(
+          route,
+          new Request(`https://nextane.test/api/isolation?token=${token}`, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${token}`,
+              cookie: `session=${token}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ token }),
+          }),
+          { token },
+        ),
+      ),
+    );
+    const bodies = await Promise.all(responses.map((response) => response.text()));
+
+    for (let index = 0; index < requestCount; index += 1) {
+      const token = tokens[index];
+      expect(responses[index].headers.get("cache-control")).toBe(
+        "private, no-store",
+      );
+      expect(responses[index].headers.get("x-request-canary")).toBe(token);
+      expect(responses[index].headers.get("set-cookie")).toContain(token);
+      expect(bodies[index]).toContain(token);
+      expect(bodies[index]).toContain(`Bearer ${token}`);
+      for (const other of tokens) {
+        if (other !== token) expect(bodies[index]).not.toContain(other);
+      }
+    }
   });
 
   it("parses JSON, form, and text bodies with Pages-style semantics", async () => {
@@ -242,6 +318,7 @@ describe("Pages Router API routes", () => {
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe("/destination");
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
   });
 
   it("keeps req.query writable and exposes a relative req.url", async () => {
@@ -290,9 +367,31 @@ describe("Pages Router API routes", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
     expect(await response.json()).toEqual({
       query: { hello: "octane", id: "dynamic" },
       body: "edge body",
     });
+  });
+
+  it("preserves an explicit API cache policy", async () => {
+    const response = await runApiRoute(
+      {
+        default(
+          _request: unknown,
+          reply: {
+            setHeader(name: string, value: string): void;
+            json(value: unknown): void;
+          },
+        ) {
+          reply.setHeader("cache-control", "public, max-age=60");
+          reply.json({ public: true });
+        },
+      },
+      new Request("https://nextane.test/api/public"),
+      {},
+    );
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
   });
 });

--- a/test/unit/handler.test.ts
+++ b/test/unit/handler.test.ts
@@ -1,5 +1,5 @@
-import { createElement } from "octane";
-import { describe, expect, it } from "vitest";
+import { createElement, use } from "octane";
+import { describe, expect, it, vi } from "vitest";
 import App from "../fixtures/upstream-app.tsrx";
 import Document from "../fixtures/upstream-document.tsrx";
 import Page from "../fixtures/upstream-page.tsrx";
@@ -127,6 +127,189 @@ describe("Pages Router server compatibility", () => {
     expect(response.headers.get("x-from-gssp")).toBe("yes");
   });
 
+  it("isolates request, response, cookie, header, and body data across overlapping GSSP HTML and data requests", async () => {
+    const requestCount = 24;
+    let entered = 0;
+    let releaseAll!: () => void;
+    const allEntered = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+    const IsolationPage = (props: Record<string, unknown>) =>
+      createElement("pre", { id: "request-isolation" }, JSON.stringify(props));
+    const isolationRoute = {
+      ...route,
+      route: "/request-isolation",
+      regexSource: "^/request-isolation/?$",
+      params: [],
+      async load() {
+        return {
+          default: IsolationPage,
+          async getServerSideProps({
+            req,
+            res,
+            query,
+          }: {
+            req: {
+              url: string;
+              cookies: Record<string, string>;
+              headers: { get(name: string): string | null };
+            };
+            res: { setHeader(name: string, value: string): void };
+            query: Record<string, unknown>;
+          }) {
+            const token = String(query.token);
+            entered += 1;
+            if (entered === requestCount) releaseAll();
+            await allEntered;
+            res.setHeader("x-request-canary", token);
+            res.setHeader(
+              "set-cookie",
+              `request-canary=${token}; Path=/; HttpOnly`,
+            );
+            return {
+              props: {
+                token,
+                authorization: req.headers.get("authorization"),
+                cookie: req.cookies.session,
+                requestUrl: req.url,
+              },
+            };
+          },
+        };
+      },
+    };
+    const handler = createNextaneHandler(
+      manifest({
+        buildId: "request-isolation-build",
+        routes: [isolationRoute],
+        loadApp: null,
+        loadDocument: null,
+      }),
+    );
+    const tokens = Array.from(
+      { length: requestCount },
+      (_, index) => `request-${String(index).padStart(2, "0")}-canary`,
+    );
+    const responses = await Promise.all(
+      tokens.map((token, index) =>
+        handler(
+          new Request(
+            index % 2 === 0
+              ? `https://nextane.test/request-isolation?token=${token}`
+              : `https://nextane.test/_next/data/request-isolation-build/request-isolation.json?token=${token}`,
+            {
+              headers: {
+                authorization: `Bearer ${token}`,
+                cookie: `session=${token}`,
+              },
+            },
+          ),
+          { ASSETS: assets },
+        ),
+      ),
+    );
+    const bodies = await Promise.all(responses.map((response) => response.text()));
+
+    for (let index = 0; index < requestCount; index += 1) {
+      const response = responses[index];
+      const body = bodies[index];
+      const token = tokens[index];
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe(
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      );
+      expect(response.headers.get("x-request-canary")).toBe(token);
+      expect(response.headers.get("set-cookie")).toContain(token);
+      expect(body).toContain(token);
+      expect(body).toContain(`Bearer ${token}`);
+      for (const other of tokens) {
+        if (other !== token) expect(body).not.toContain(other);
+      }
+    }
+  });
+
+  it("isolates Octane suspense state and Router state across concurrent SSR passes", async () => {
+    const requestCount = 16;
+    let entered = 0;
+    let releaseAll!: () => void;
+    const allEntered = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+    const SuspendedPage = ({
+      delayedIdentity,
+    }: {
+      delayedIdentity: Promise<string>;
+    }) =>
+      createElement(
+        "main",
+        {},
+        createElement("p", { id: "resolved-identity" }, use(delayedIdentity)),
+        createElement("p", { id: "router-identity" }, Router.asPath),
+      );
+    const suspenseRoute = {
+      ...route,
+      route: "/suspense-isolation",
+      regexSource: "^/suspense-isolation/?$",
+      params: [],
+      async load() {
+        return {
+          default: SuspendedPage,
+          async getServerSideProps({
+            query,
+          }: {
+            query: Record<string, unknown>;
+          }) {
+            const token = String(query.token);
+            entered += 1;
+            if (entered === requestCount) releaseAll();
+            await allEntered;
+            return {
+              props: {
+                delayedIdentity: new Promise<string>((resolve) => {
+                  setTimeout(
+                    () => resolve(`resolved:${token}`),
+                    (requestCount - entered) % 4,
+                  );
+                }),
+              },
+            };
+          },
+        };
+      },
+    };
+    const handler = createNextaneHandler(
+      manifest({
+        routes: [suspenseRoute],
+        loadApp: null,
+        loadDocument: null,
+      }),
+    );
+    const tokens = Array.from(
+      { length: requestCount },
+      (_, index) => `render-${String(index).padStart(2, "0")}-canary`,
+    );
+    const bodies = await Promise.all(
+      tokens.map((token) =>
+        handler(
+          new Request(
+            `https://nextane.test/suspense-isolation?token=${token}`,
+          ),
+          { ASSETS: assets },
+        ).then((response) => response.text()),
+      ),
+    );
+
+    for (let index = 0; index < requestCount; index += 1) {
+      expect(bodies[index]).toContain(`resolved:${tokens[index]}`);
+      expect(bodies[index]).toContain(
+        `/suspense-isolation?token=${tokens[index]}`,
+      );
+      for (const other of tokens) {
+        if (other !== tokens[index]) expect(bodies[index]).not.toContain(other);
+      }
+    }
+  });
+
   it("supports Document.getInitialProps renderPage component enhancers", async () => {
     const handler = createNextaneHandler(manifest());
     const response = await handler(
@@ -206,7 +389,67 @@ describe("Pages Router server compatibility", () => {
 
     expect(response.status).toBe(202);
     expect(response.headers.get("x-early")).toBe("yes");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
     expect(await response.text()).toBe("hello from gssp");
+  });
+
+  it("keeps request-dependent GSSP redirects private by default", async () => {
+    const redirectRoute = {
+      ...route,
+      route: "/private-redirect",
+      regexSource: "^/private-redirect/?$",
+      params: [],
+      async load() {
+        return {
+          default: Page,
+          getServerSideProps({
+            query,
+          }: {
+            query: Record<string, unknown>;
+          }) {
+            return {
+              redirect: {
+                destination: `/account/${String(query.user)}`,
+                permanent: true,
+              },
+            };
+          },
+        };
+      },
+    };
+    const handler = createNextaneHandler(
+      manifest({
+        routes: [redirectRoute],
+        loadApp: null,
+        loadDocument: null,
+      }),
+    );
+    const [first, second] = await Promise.all([
+      handler(
+        new Request("https://nextane.test/private-redirect?user=first"),
+        { ASSETS: assets },
+      ),
+      handler(
+        new Request("https://nextane.test/private-redirect?user=second"),
+        { ASSETS: assets },
+      ),
+    ]);
+
+    expect(first.status).toBe(308);
+    expect(second.status).toBe(308);
+    expect(first.headers.get("location")).toBe(
+      "https://nextane.test/account/first",
+    );
+    expect(second.headers.get("location")).toBe(
+      "https://nextane.test/account/second",
+    );
+    for (const response of [first, second]) {
+      expect(response.headers.get("cache-control")).toBe(
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      );
+    }
   });
 
   it("renders POST requests without forwarding the method to the HTML asset lookup", async () => {
@@ -778,46 +1021,48 @@ describe("Pages Router server compatibility", () => {
       url: string;
       headers: Array<[string, string]>;
     }> = [];
-    let cachedArtifact: Response | undefined;
+    let cachedArtifact: Promise<Response> | undefined;
     const handler = createNextaneHandler(staticManifest, {
       async loadCachedArtifact(request) {
         artifactRequests.push({
           url: request.url,
           headers: [...request.headers],
         });
-        cachedArtifact ??= await artifactHandler(request);
-        return cachedArtifact.clone();
+        cachedArtifact ??= artifactHandler(request);
+        return (await cachedArtifact).clone();
       },
     });
-    const attacker = await handler(
-      new Request(
-        "https://attacker.test/static/value?secret=QUERY_SECRET",
-        {
-          headers: {
-            authorization: "Bearer HEADER_SECRET",
-            cookie: "session=COOKIE_SECRET",
-            "accept-language": "LANGUAGE_SECRET",
-            "user-agent": "AGENT_SECRET",
-            "x-nextane-only-cached": "1",
+    const [attacker, victim] = await Promise.all([
+      handler(
+        new Request(
+          "https://attacker.test/static/value?secret=QUERY_SECRET",
+          {
+            headers: {
+              authorization: "Bearer HEADER_SECRET",
+              cookie: "session=COOKIE_SECRET",
+              "accept-language": "LANGUAGE_SECRET",
+              "user-agent": "AGENT_SECRET",
+              "x-nextane-only-cached": "1",
+            },
           },
-        },
+        ),
+        { ASSETS: assets },
       ),
-      { ASSETS: assets },
-    );
-    const victim = await handler(
-      new Request(
-        "https://victim.test/static/value?secret=VICTIM_QUERY",
-        {
-          headers: {
-            authorization: "Bearer VICTIM_HEADER",
-            cookie: "session=VICTIM_COOKIE",
-            "accept-language": "VICTIM_LANGUAGE",
-            "user-agent": "VICTIM_AGENT",
+      handler(
+        new Request(
+          "https://victim.test/static/value?secret=VICTIM_QUERY",
+          {
+            headers: {
+              authorization: "Bearer VICTIM_HEADER",
+              cookie: "session=VICTIM_COOKIE",
+              "accept-language": "VICTIM_LANGUAGE",
+              "user-agent": "VICTIM_AGENT",
+            },
           },
-        },
+        ),
+        { ASSETS: assets },
       ),
-      { ASSETS: assets },
-    );
+    ]);
     const attackerHtml = await attacker.text();
     const victimHtml = await victim.text();
 
@@ -860,6 +1105,168 @@ describe("Pages Router server compatibility", () => {
     expect(victimHtml).toBe(attackerHtml);
     expect(attackerHtml).toContain('"resolvedPath":"/static/value"');
     expect(attackerHtml).toContain('"buildId":"canonical-build"');
+  });
+
+  it("fails closed if a shared cache returns an artifact for another path", async () => {
+    const StaticTenantPage = ({ tenant }: { tenant: string }) =>
+      createElement("p", { id: "tenant" }, tenant);
+    const tenantRoute = {
+      ...route,
+      route: "/tenant/[tenant]",
+      regexSource: "^/tenant/([^/]+)/?$",
+      params: [{ name: "tenant", kind: "single" as const }],
+      async load() {
+        return {
+          default: StaticTenantPage,
+          getStaticProps({
+            params,
+          }: {
+            params: Record<string, string>;
+          }) {
+            return {
+              props: { tenant: `${params.tenant}-private-artifact` },
+              revalidate: 60,
+            };
+          },
+        };
+      },
+    };
+    const tenantManifest = manifest({
+      buildId: "tenant-build",
+      routes: [tenantRoute],
+      loadApp: null,
+      loadDocument: null,
+    });
+    const artifactHandler = createIsrArtifactHandler(tenantManifest);
+    const attackerArtifact = await artifactHandler(
+      new Request("https://nextane.internal/tenant/attacker"),
+    );
+    const attackerBody = await attackerArtifact.text();
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const handler = createNextaneHandler(tenantManifest, {
+        async loadCachedArtifact() {
+          return new Response(attackerBody, {
+            status: attackerArtifact.status,
+            headers: attackerArtifact.headers,
+          });
+        },
+      });
+      const victim = await handler(
+        new Request("https://nextane.test/tenant/victim"),
+        { ASSETS: assets },
+      );
+      const victimHtml = await victim.text();
+
+      expect(victim.status).toBe(500);
+      expect(victim.headers.get("cache-control")).toBe("private, no-store");
+      expect(victimHtml).not.toContain("attacker-private-artifact");
+      expect(error).toHaveBeenCalledWith(
+        "[nextane] request failed",
+        expect.objectContaining({
+          message: "Shared ISR cache returned a mismatched artifact",
+        }),
+      );
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it("rejects tampered shared artifacts instead of serving potentially cross-user data", async () => {
+    const StaticTenantPage = ({ tenant }: { tenant: string }) =>
+      createElement("p", { id: "tenant" }, tenant);
+    const tenantRoute = {
+      ...route,
+      route: "/validated/[tenant]",
+      regexSource: "^/validated/([^/]+)/?$",
+      params: [{ name: "tenant", kind: "single" as const }],
+      async load() {
+        return {
+          default: StaticTenantPage,
+          getStaticProps({
+            params,
+          }: {
+            params: Record<string, string>;
+          }) {
+            return {
+              props: { tenant: params.tenant },
+              revalidate: 60,
+            };
+          },
+        };
+      },
+    };
+    const tenantManifest = manifest({
+      buildId: "validated-build",
+      routes: [tenantRoute],
+      loadApp: null,
+      loadDocument: null,
+    });
+    const canonicalResponse = await createIsrArtifactHandler(tenantManifest)(
+      new Request("https://nextane.internal/validated/victim"),
+    );
+    const canonicalArtifact = (await canonicalResponse.json()) as Record<
+      string,
+      any
+    >;
+    const mutations: Array<
+      [string, (artifact: Record<string, any>) => void]
+    > = [
+      ["build ID", (artifact) => { artifact.buildId = "attacker-build"; }],
+      ["route", (artifact) => { artifact.route = "/validated/[other]"; }],
+      [
+        "resolved path",
+        (artifact) => { artifact.resolvedPath = "/validated/attacker"; },
+      ],
+      [
+        "query variance",
+        (artifact) => { artifact.query = { tenant: "victim", user: "attacker" }; },
+      ],
+      ["GSP marker", (artifact) => { artifact.gsp = false; }],
+      ["GSSP marker", (artifact) => { artifact.gssp = true; }],
+      ["cacheable marker", (artifact) => { artifact.cacheable = false; }],
+      ["fallback marker", (artifact) => { artifact.isFallback = true; }],
+      [
+        "App props",
+        (artifact) => { artifact.appProps = { user: "attacker" }; },
+      ],
+      [
+        "response cookie",
+        (artifact) => {
+          artifact.response.headers = [
+            ["set-cookie", "session=attacker; Path=/; HttpOnly"],
+          ];
+        },
+      ],
+      ["response status", (artifact) => { artifact.response.status = 201; }],
+      ["generation timestamp", (artifact) => { artifact.generatedAt = null; }],
+    ];
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      for (const [name, mutate] of mutations) {
+        const tampered = structuredClone(canonicalArtifact);
+        mutate(tampered);
+        const handler = createNextaneHandler(tenantManifest, {
+          async loadCachedArtifact() {
+            return Response.json(tampered);
+          },
+        });
+        const response = await handler(
+          new Request("https://nextane.test/validated/victim"),
+          { ASSETS: assets },
+        );
+        const html = await response.text();
+
+        expect(response.status, name).toBe(500);
+        expect(response.headers.get("cache-control"), name).toBe(
+          "private, no-store",
+        );
+        expect(html, name).not.toContain("attacker");
+      }
+      expect(error).toHaveBeenCalledTimes(mutations.length);
+    } finally {
+      error.mockRestore();
+    }
   });
 
   it("rejects ambiguous rewrite patterns before processing attacker paths", () => {

--- a/worker.ts
+++ b/worker.ts
@@ -27,39 +27,35 @@ const manifest = {
   config,
 };
 const handleIsrArtifact = createIsrArtifactHandler(manifest);
-const localArtifactCache = new Map<
-  string,
-  { body: string; headers: [string, string][]; expiresAt: number }
->();
-
-function maxAge(cacheControl: string | null): number {
-  const match = /(?:^|,)\s*max-age=(\d+)/i.exec(cacheControl ?? "");
-  return match ? Number(match[1]) : 0;
-}
+const runtimeCaches = caches as CacheStorage & { default: Cache };
 
 async function loadLocalArtifact(request: Request): Promise<Response> {
-  const key = `${buildId}:${new URL(request.url).pathname}`;
-  const cached = localArtifactCache.get(key);
-  if (cached && cached.expiresAt > Date.now()) {
+  const cacheRequest = namespaceIsrCacheRequest(request, buildId);
+  const cached = await runtimeCaches.default.match(cacheRequest);
+  if (cached) {
     const headers = new Headers(cached.headers);
     headers.set("x-cache-status", "HIT");
-    return new Response(cached.body, { headers });
+    return new Response(cached.body, {
+      status: cached.status,
+      statusText: cached.statusText,
+      headers,
+    });
   }
   if (request.headers.get("x-nextane-only-cached") === "1") {
     return new Response("ISR artifact not cached", { status: 404 });
   }
 
   const response = await handleIsrArtifact(request);
-  const body = await response.text();
-  const headers = [...response.headers.entries()];
-  localArtifactCache.set(key, {
-    body,
-    headers,
-    expiresAt: Date.now() + maxAge(response.headers.get("cache-control")) * 1000,
-  });
-  const missHeaders = new Headers(headers);
+  if (response.ok) {
+    await runtimeCaches.default.put(cacheRequest, response.clone());
+  }
+  const missHeaders = new Headers(response.headers);
   missHeaders.set("x-cache-status", "MISS");
-  return new Response(body, { status: response.status, headers: missHeaders });
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: missHeaders,
+  });
 }
 
 export class IsrArtifact extends WorkerEntrypoint<NextaneEnvironment> {
@@ -78,8 +74,14 @@ export default {
         );
       },
       async revalidatePath(pathname) {
-        localArtifactCache.delete(`${buildId}:${pathname}`);
-        if (import.meta.env.DEV) return true;
+        if (import.meta.env.DEV) {
+          const canonical = new Request(
+            new URL(pathname, "https://nextane.internal"),
+          );
+          return runtimeCaches.default.delete(
+            namespaceIsrCacheRequest(canonical, buildId),
+          );
+        }
         if (!ctx.cache) return false;
         const result = await ctx.cache.purge({
           tags: [cacheTagForPath(pathname)],


### PR DESCRIPTION
## What changed

- remove the framework's development-time process-global ISR response map and
  use the Workers Cache API instead
- canonicalize shared GSP/ISR generation and validate cached artifacts against
  their build, route, pathname, params, response state, and cacheability before
  rendering
- default GSSP, early response, redirect, and API responses to private/no-store
  unless an API route explicitly opts into caching
- add deterministic concurrent canary tests for GSSP HTML/data, APIs, Octane
  Suspense rendering, router state, request headers/cookies/bodies, cache
  poisoning, and malformed shared artifacts
- exercise the same isolation matrix through an externally installed npm
  tarball and against the deployed Worker
- refresh the benchmark and compatibility documentation

## Why

A process-global response cache or request-scoped state stored outside the
request can expose one user's data to another request in a long-lived Worker
isolate. Shared caching must be limited to request-independent static artifacts
and must fail closed if the cache returns an artifact for another route or
deployment.

## Verification

- `npm run check`
- `npm run test:package`
- `npm run test:package:security`
- `npm run test:example`
- `npm audit --audit-level=high`
- upstream Pages suite: 251/252 substantive assertions, with only the
  intentional fail-closed Preview Mode case
- six of six browser flows against the deployed Worker
- independent 300-request production burst: 100 GSSP/data, 100 API, and 100
  shared GSP requests with zero cross-request canary leaks
