### PR TITLE
Fix four i18n/routing defects found in adversarial review

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -44,7 +44,7 @@ larger Next.js Pages Router compatibility claim.
 
 The prototype-owned suite currently has:
 
-- **93/93 unit and security tests** covering route discovery/matching, classic
+- **96/96 unit and security tests** covering route discovery/matching, classic
   and Edge API request/response adaptation, URL normalization, cache isolation,
   Preview Mode signing and bypass semantics, redirects/headers/conditional
   rewrites and their phase order (a real page beats an `afterFiles` rewrite),

--- a/src/runtime/navigation.ts
+++ b/src/runtime/navigation.ts
@@ -60,7 +60,9 @@ export function withLocalePrefix(
 ): string {
   if (defaultLocale === undefined) return target;
   if (locale === false) return target;
-  if (!target.startsWith("/")) return target;
+  // Only route-space paths are localized; leave external, protocol-relative
+  // (`//host`), and relative targets untouched.
+  if (!target.startsWith("/") || target.startsWith("//")) return target;
   const resolved = typeof locale === "string" ? locale : currentLocale;
   if (!resolved || resolved === defaultLocale) return target;
   const boundary = target.search(/[?#]/);

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -2137,24 +2137,28 @@ export function createNextaneHandler(
       // but never a static page.
       const matchedStaticPage = !!match && match.route.params.length === 0;
       if (!matchedStaticPage && !presetRouting && afterFilesRewrites.length > 0) {
+        // afterFiles operates on the path as it stands after the beforeFiles
+        // phase (Next.js chains the phases), so resolve against the
+        // beforeFiles-rewritten path when one actually fired.
+        const afterBaseUrl = routing.matched ? routing.pageUrl : routingUrl;
+        const afterLocalized = routing.matched
+          ? routing.pageUrl.pathname
+          : localizedPathname;
         const afterFiles = resolveRewrite(
           afterFilesRewrites,
-          routingUrl,
+          afterBaseUrl,
           ruleContext,
-          localizedPathname,
+          afterLocalized,
         );
         if (afterFiles.external) {
           return proxyExternalRewrite(request, afterFiles.external);
         }
         if (afterFiles.matched) {
-          const afterMatch = matchRoute(
-            manifest.routes,
-            afterFiles.pageUrl.pathname,
-          );
-          if (afterMatch) {
-            match = afterMatch;
-            routing = afterFiles;
-          }
+          // A fired afterFiles rewrite consumes the request: adopt its
+          // destination even when that resolves to no route, so the request
+          // 404s rather than falling back to the pre-rewrite dynamic match.
+          match = matchRoute(manifest.routes, afterFiles.pageUrl.pathname);
+          routing = afterFiles;
         }
       }
       if (!match) {
@@ -2317,16 +2321,13 @@ export function createNextaneHandler(
       const url = new URL(sanitized.url);
       // i18n: match non-`locale:false` header rules against the locale-stripped
       // path (Next applies them across all locales), and `locale:false` rules
-      // against the locale-included path.
+      // against the actual request path (`url.pathname`) — which already carries
+      // the locale prefix for non-default locales and stays unprefixed for the
+      // default locale, exactly as the request URL does.
       let headerPathname = url.pathname;
-      let localizedPathname = url.pathname;
+      const localizedPathname = url.pathname;
       if (i18n && !url.pathname.startsWith("/_next/")) {
-        const resolution = resolveLocale(url.pathname, i18n);
-        headerPathname = resolution.pathname;
-        localizedPathname = addLocalePrefix(
-          resolution.pathname,
-          resolution.locale,
-        );
+        headerPathname = resolveLocale(url.pathname, i18n).pathname;
       }
       const applied = matchHeaderRules(
         headerRules,

--- a/test/unit/i18n-server.test.ts
+++ b/test/unit/i18n-server.test.ts
@@ -179,6 +179,30 @@ describe("i18n header rules", () => {
     );
     expect(prefixed.headers.get("x-custom")).toBe("1");
   });
+
+  it("applies locale:false header rules to default-locale (unprefixed) requests", async () => {
+    const handler = createNextaneHandler(
+      i18nManifest({
+        config: {
+          i18n: { ...I18N },
+          headers: [
+            {
+              source: "/about",
+              locale: false,
+              headers: [{ key: "x-ignore-locale", value: "1" }],
+            },
+          ],
+        },
+      }),
+    );
+
+    // The default locale is served unprefixed, so a `locale: false` source must
+    // match the raw `/about` path — not a phantom `/en/about`.
+    const dflt = await handler(new Request("https://nextane.test/about"), {
+      ASSETS: assets,
+    });
+    expect(dflt.headers.get("x-ignore-locale")).toBe("1");
+  });
 });
 
 describe("i18n data requests", () => {
@@ -262,5 +286,70 @@ describe("afterFiles rewrite phase order", () => {
       { ASSETS: assets },
     );
     expect(await rewritten.text()).toContain("TEAM");
+  });
+
+  it("resolves afterFiles against the beforeFiles-rewritten path, not the original", async () => {
+    const articles = {
+      route: "/articles/[slug]",
+      regexSource: "^/articles/([^/]+)/?$",
+      params: [{ name: "slug", kind: "single" as const }],
+      id: 3,
+      kind: "page" as const,
+      async load() {
+        return { default: () => createElement("p", { id: "page" }, "ARTICLE") };
+      },
+    };
+    const handler = createNextaneHandler({
+      routes: [articles, labeledPage("/other-internal", "OTHER")],
+      loadApp: null,
+      loadDocument: null,
+      loadError: null,
+      buildId: "test-build",
+      config: {
+        rewrites: [
+          {
+            source: "/legacy/:slug",
+            destination: "/articles/:slug",
+            phase: "beforeFiles",
+          },
+          {
+            source: "/legacy/:path*",
+            destination: "/other-internal",
+            phase: "afterFiles",
+          },
+        ],
+      },
+    });
+
+    // beforeFiles rewrites /legacy/hello -> /articles/hello (a dynamic route);
+    // the afterFiles source no longer matches the rewritten path, so the
+    // article renders instead of the afterFiles destination.
+    const res = await handler(
+      new Request("https://nextane.test/legacy/hello"),
+      { ASSETS: assets },
+    );
+    const html = await res.text();
+    expect(html).toContain("ARTICLE");
+    expect(html).not.toContain("OTHER");
+  });
+
+  it("404s when a fired afterFiles rewrite resolves to no route", async () => {
+    const handler = createNextaneHandler({
+      routes: [dynamicSlugPage("SLUG")],
+      loadApp: null,
+      loadDocument: null,
+      loadError: null,
+      buildId: "test-build",
+      config: {
+        rewrites: [{ source: "/promo", destination: "/campaigns/summer" }],
+      },
+    });
+
+    // /promo matches [slug], but the afterFiles rewrite fires to
+    // /campaigns/summer, which has no route -> 404 (not a stale [slug] render).
+    const res = await handler(new Request("https://nextane.test/promo"), {
+      ASSETS: assets,
+    });
+    expect(res.status).toBe(404);
   });
 });

--- a/test/unit/router.test.ts
+++ b/test/unit/router.test.ts
@@ -246,6 +246,11 @@ describe("withLocalePrefix", () => {
     expect(withLocalePrefix("https://x/y", "de", "en", "en")).toBe(
       "https://x/y",
     );
+    // Protocol-relative external hrefs are left alone (not turned into
+    // `/de//cdn.example.com/x`).
+    expect(withLocalePrefix("//cdn.example.com/x", "de", "en", "en")).toBe(
+      "//cdn.example.com/x",
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up to #24. An adversarial review of that change surfaced four defects — two majors that were regressions introduced by #24's i18n header/afterFiles work — each fixed here with a regression test.

## Fixes

- **`locale: false` header rules on default-locale requests (major).** The i18n header block matched `locale: false` rules against a phantom `/{defaultLocale}`-prefixed path, so a `locale: false` header rule silently stopped applying to unprefixed default-locale requests. Now matches against the actual request path (`url.pathname`), which already carries the locale prefix for non-default locales and stays unprefixed for the default.
- **afterFiles resolved against the wrong path (major).** The `afterFiles` phase re-resolved against the original request path instead of the `beforeFiles`-rewritten path. A `beforeFiles` rewrite that landed on a dynamic route could be hijacked by an `afterFiles` source that only matched the original path — misrouting an internal page to an external proxy. Now resolves against the post-`beforeFiles` path, matching Next.js's per-phase chaining.
- **Fired afterFiles rewrite to a dead route (minor).** When an `afterFiles` rewrite fired but its destination resolved to no route, the request fell back to the pre-rewrite dynamic match and rendered it. Now the fired rewrite consumes the request and it 404s, as in Next.js.
- **`withLocalePrefix` on protocol-relative hrefs (minor).** `<Link href="//host/x">` under a non-default locale was mangled into `/{locale}//host/x` and intercepted as an internal navigation. Protocol-relative external hrefs are now left untouched.

## Testing

- 96 unit and security tests (`npm test`), including a regression test for each fix.
- Full 43-file upstream deploy-test harness re-run: no regressions (only the pre-existing environment-limited `example.vercel.sh` egress case fails). The changed paths (`afterFiles` rewrites, `locale: false` headers, protocol-relative links) are new scenarios not previously exercised, so the existing suites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC)_