### PR TITLE
Restore i18n default-locale insertion for locale:false header rules

### DIFF
--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -2320,14 +2320,16 @@ export function createNextaneHandler(
     if (headerRules.length > 0 && response.status !== 101) {
       const url = new URL(sanitized.url);
       // i18n: match non-`locale:false` header rules against the locale-stripped
-      // path (Next applies them across all locales), and `locale:false` rules
-      // against the actual request path (`url.pathname`) — which already carries
-      // the locale prefix for non-default locales and stays unprefixed for the
-      // default locale, exactly as the request URL does.
+      // path (Next applies them across all locales). `locale:false` rules match
+      // against the locale-inserted path — the default locale is inserted even
+      // for an unprefixed request — so a `:locale`-spelling source matches every
+      // locale, exactly as Next's `processRoutes` builds these rules.
       let headerPathname = url.pathname;
-      const localizedPathname = url.pathname;
+      let localizedPathname = url.pathname;
       if (i18n && !url.pathname.startsWith("/_next/")) {
-        headerPathname = resolveLocale(url.pathname, i18n).pathname;
+        const resolution = resolveLocale(url.pathname, i18n);
+        headerPathname = resolution.pathname;
+        localizedPathname = addLocalePrefix(resolution.pathname, resolution.locale);
       }
       const applied = matchHeaderRules(
         headerRules,

--- a/test/unit/i18n-server.test.ts
+++ b/test/unit/i18n-server.test.ts
@@ -180,28 +180,36 @@ describe("i18n header rules", () => {
     expect(prefixed.headers.get("x-custom")).toBe("1");
   });
 
-  it("applies locale:false header rules to default-locale (unprefixed) requests", async () => {
+  it("matches locale:false header rules against the locale-inserted path", async () => {
     const handler = createNextaneHandler(
       i18nManifest({
         config: {
           i18n: { ...I18N },
           headers: [
             {
-              source: "/about",
+              source: "/:locale/about",
               locale: false,
-              headers: [{ key: "x-ignore-locale", value: "1" }],
+              headers: [{ key: "x-loc", value: "yes" }],
             },
           ],
         },
       }),
     );
 
-    // The default locale is served unprefixed, so a `locale: false` source must
-    // match the raw `/about` path — not a phantom `/en/about`.
+    // A `locale: false` source that spells out `:locale` matches every locale,
+    // including the default locale inserted for the unprefixed request — the
+    // same rule Next's `processRoutes` applies to redirects, rewrites, and
+    // headers alike.
     const dflt = await handler(new Request("https://nextane.test/about"), {
       ASSETS: assets,
     });
-    expect(dflt.headers.get("x-ignore-locale")).toBe("1");
+    expect(dflt.headers.get("x-loc")).toBe("yes");
+
+    const prefixed = await handler(
+      new Request("https://nextane.test/fr/about"),
+      { ASSETS: assets },
+    );
+    expect(prefixed.headers.get("x-loc")).toBe("yes");
   });
 });
 


### PR DESCRIPTION
Corrects one change from #25. That PR made `locale: false` header rules match against the raw request path (`url.pathname`), but that diverges from Next.js.

Next builds redirects, rewrites, and headers with the same `processRoutes`, and `locale: false` rules are matched against the **locale-inserted** path — the default locale is inserted even for an unprefixed request. So a `:locale`-spelling source like `/:locale/about` must match every locale including the default (`/about` → `/en/about`), and a bare source is matched against the inserted path, not the raw one.

This is confirmed by the upstream `i18n-ignore-redirect-source-locale` suite, which uses `locale: false` sources such as `/:locale/to-sv` and asserts they redirect the **unprefixed default** request — only possible if the default locale is inserted before matching. The redirect and rewrite paths already do this (`addLocalePrefix`); this restores the same for headers so all three are consistent.

## Change

- Header matching uses `addLocalePrefix(strippedPath, locale)` for the `locale: false` comparison path again, instead of the raw request path.
- The regression test now asserts the correct behavior: a `locale: false` `/:locale/about` header applies to both the unprefixed default request and a locale-prefixed one.

## Testing

- 96 unit and security tests (`npm test`).
- Full 43-file upstream deploy-test harness: no regressions (only the pre-existing egress-limited `example.vercel.sh` case fails). No fixture exercises i18n + custom headers, so this change is inert for the suite; the `i18n-ignore-redirect-source-locale` suite continues to pass and pins the underlying insertion behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC)_