### PR TITLE
Don't strip non-exported locals that share a reserved server-export name

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -44,7 +44,7 @@ larger Next.js Pages Router compatibility claim.
 
 The prototype-owned suite currently has:
 
-- **106/106 unit and security tests** covering route discovery/matching, classic
+- **108/108 unit and security tests** covering route discovery/matching, classic
   and Edge API request/response adaptation, URL normalization, cache isolation,
   Preview Mode signing and bypass semantics, redirects/headers/conditional
   rewrites and their phase order (a real page beats an `afterFiles` rewrite),

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -398,7 +398,11 @@ export async function createClientPageSource(
 
   const edits: TextEdit[] = [];
   const serverRoots: AstNode[] = [];
-  const serverBindings = new Set(SERVER_PAGE_EXPORTS);
+  // Only names actually EXPORTED as server page exports are stripped; the loop
+  // below populates this. Seeding it with every SERVER_PAGE_EXPORTS name would
+  // wrongly strip a non-exported local that merely shares a reserved name
+  // (e.g. `const config = ...` used by the component).
+  const serverBindings = new Set<string>();
   const body = moduleBody(program);
 
   for (const statement of body) {

--- a/test/unit/plugin-security.test.ts
+++ b/test/unit/plugin-security.test.ts
@@ -62,6 +62,36 @@ describe("client build security", () => {
     expect(transformed).not.toContain("serverCanary");
   });
 
+  it("keeps a non-exported local that shares a reserved server-export name", async () => {
+    const transformed = await createClientPageSource(
+      `
+        const config = { pageSize: 20 };
+        export default function Page({ items }) {
+          return <ul>{items.slice(0, config.pageSize)}</ul>;
+        }
+      `,
+      "reserved-local.tsrx",
+    );
+    // The local `config` (not an export) must survive so the component works.
+    expect(transformed).toContain("const config = { pageSize: 20 }");
+    expect(transformed).toContain("config.pageSize");
+  });
+
+  it("still strips an exported config from the client bundle", async () => {
+    const transformed = await createClientPageSource(
+      `
+        export const config = { runtime: "edge", secretFlag: "SERVER_ONLY" };
+        export default function Page() {
+          return <p>hi</p>;
+        }
+      `,
+      "exported-config.tsrx",
+    );
+    expect(transformed).not.toContain("SERVER_ONLY");
+    expect(transformed).not.toContain("runtime");
+    expect(transformed).toContain("default function Page");
+  });
+
   it("preserves a default re-export while dropping a server re-export", async () => {
     const transformed = await createClientPageSource(
       `


### PR DESCRIPTION
The client-bundle stripper (`createClientPageSource`) seeded its server-binding set with **every** reserved server-export name (`config`, `getServerSideProps`, `getStaticProps`, `getStaticPaths`, `getInitialProps`). So a non-exported top-level local that merely shared one of those names — e.g. `const config = { pageSize: 20 }` used by the page component — was removed from the client bundle while the component still referenced it, producing a `ReferenceError` (or an unresolved-reference build error) at hydration. The SSR HTML was correct, so the page rendered and then broke in the browser.

Fix: start the server-binding set empty. The existing pass already adds names that are actually **exported** as server page exports, so real `getStaticProps`/`getServerSideProps`/`config` exports are still stripped; only the erroneous name-based removal of unrelated locals is dropped.

## Testing

- 108 unit and security tests (`npm test`), with regression tests for both directions (a non-exported `config` local is kept; an exported `config` is still stripped).
- Full 43-file upstream deploy-test harness: no regressions (only the pre-existing egress-limited `example.vercel.sh` case fails).

_Found by an adversarial review of the plugin build pipeline. Three further findings from that review — a server-only import that leaks into the client bundle when a client-scope local shares the imported name (needs scope-aware analysis to avoid breaking legitimately-shared imports), and `next/head` placing `<meta>`/`<link>` in `<body>` and not de-duplicating (depends on the Octane head-channel hoisting) — are deeper changes and are intentionally left for dedicated follow-ups rather than bundled here._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC)_