### PR TITLE
Stop leaking a server-only import shadowed by a same-named client local

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -229,6 +229,93 @@ function declarationNames(node: AstNode): string[] {
   return bindingNames(astNode(node.id));
 }
 
+function statementBindsName(statement: AstNode, name: string): boolean {
+  const declaration =
+    statement.type === "ExportNamedDeclaration"
+      ? astNode(statement.declaration)
+      : statement;
+  if (!declaration) return false;
+  if (
+    declaration.type === "VariableDeclaration" ||
+    declaration.type === "FunctionDeclaration" ||
+    declaration.type === "ClassDeclaration"
+  ) {
+    return declarationNames(declaration).includes(name);
+  }
+  return false;
+}
+
+// Whether `node` introduces a lexical scope that binds `name` directly: a
+// function/arrow's params (or a function expression's own name), a catch
+// param, a for-head declaration, or a block's own direct declarations. Used to
+// tell a reference to an imported binding apart from a same-named local that
+// shadows it.
+function scopeBindsName(node: AstNode, name: string): boolean {
+  if (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  ) {
+    const id = astNode(node.id);
+    if (id && id.name === name) return true;
+    if (Array.isArray(node.params)) {
+      for (const value of node.params) {
+        const param = astNode(value);
+        if (param && bindingNames(param).includes(name)) return true;
+      }
+    }
+    return false;
+  }
+  if (node.type === "CatchClause") {
+    const param = astNode(node.param);
+    return param ? bindingNames(param).includes(name) : false;
+  }
+  if (
+    node.type === "ForStatement" ||
+    node.type === "ForInStatement" ||
+    node.type === "ForOfStatement"
+  ) {
+    const head = astNode(node.init) ?? astNode(node.left);
+    return head?.type === "VariableDeclaration"
+      ? declarationNames(head).includes(name)
+      : false;
+  }
+  if (node.type === "BlockStatement" || node.type === "StaticBlock") {
+    const body = Array.isArray(node.body) ? node.body : [];
+    return body.some((value) => {
+      const statement = astNode(value);
+      return statement ? statementBindsName(statement, name) : false;
+    });
+  }
+  return false;
+}
+
+// Whether `name` is referenced anywhere in `node` at a position where it still
+// resolves to the outer (module-level import) binding — i.e. not shadowed by an
+// intervening local scope. Conservative by construction: a reference is treated
+// as shadowed only when a real binding of `name` is found in an enclosing
+// scope, so a genuinely-used import is never reported as unused (which would
+// wrongly strip it from the client bundle). Missing a shadow only keeps an
+// import that could have been dropped — safe, never a leak of a used binding.
+function hasUnshadowedReference(
+  node: AstNode,
+  name: string,
+  shadowed: boolean,
+): boolean {
+  const innerShadowed = shadowed || scopeBindsName(node, name);
+  if (
+    !innerShadowed &&
+    (node.type === "Identifier" || node.type === "JSXIdentifier") &&
+    node.name === name
+  ) {
+    return true;
+  }
+  for (const child of childNodes(node)) {
+    if (hasUnshadowedReference(child, name, innerShadowed)) return true;
+  }
+  return false;
+}
+
 function declarationFromStatement(node: AstNode): AstNode | null {
   if (node.type === "ExportNamedDeclaration") {
     return astNode(node.declaration);
@@ -527,6 +614,22 @@ export async function createClientPageSource(
     new Set(clientRootNodes.flatMap((root) => [...collectIdentifiers(root)])),
     declarations,
   );
+  // Nodes that survive into the client bundle: the client roots plus the
+  // module-level declarations they reach. An import is genuinely used by the
+  // client only when one of these references its name at a scope where the
+  // import binding is still visible (see hasUnshadowedReference).
+  const clientRegionNodes = [
+    ...clientRootNodes,
+    ...declarations
+      .filter((declaration) =>
+        declaration.names.some((name) => clientReferences.has(name)),
+      )
+      .map((declaration) => declaration.node),
+  ];
+  const clientUsesImport = (name: string): boolean =>
+    clientRegionNodes.some((node) =>
+      hasUnshadowedReference(node, name, false),
+    );
 
   const dependencyEdits: TextEdit[] = [];
   for (const declaration of declarations) {
@@ -558,11 +661,11 @@ export async function createClientPageSource(
     if (specifiers.length === 0) continue;
     const kept = specifiers.filter((specifier) => {
       const name = importSpecifierName(specifier);
-      return (
-        !name ||
-        !serverReferences.has(name) ||
-        clientReferences.has(name)
-      );
+      // Keep the import unless it is server-referenced AND the client never
+      // uses it at a scope where its binding is visible. A same-named client
+      // local no longer counts as a use, so a server-only import stops leaking
+      // into the browser bundle when a client scope reuses its name.
+      return !name || !serverReferences.has(name) || clientUsesImport(name);
     });
     if (kept.length === specifiers.length) continue;
     dependencyEdits.push({

--- a/test/unit/plugin-security.test.ts
+++ b/test/unit/plugin-security.test.ts
@@ -62,6 +62,76 @@ describe("client build security", () => {
     expect(transformed).not.toContain("serverCanary");
   });
 
+  it("strips a server-only import shadowed by a same-named client local", async () => {
+    const transformed = await createClientPageSource(
+      `
+        import { formatSecret } from "./server-only";
+        export const getServerSideProps = async () => ({
+          props: { s: formatSecret("SERVER_SEED") },
+        });
+        export default function Page({ items }) {
+          // A client local reuses the import's name; the component only ever
+          // calls this local, never the server-only import.
+          const formatSecret = (value) => value.toUpperCase();
+          return <p>{formatSecret(items[0])}</p>;
+        }
+      `,
+      "shadowed-import.tsrx",
+    );
+    // The server-only module must not leak in just because a client local
+    // happens to share the imported binding's name.
+    expect(transformed).not.toContain("./server-only");
+    expect(transformed).not.toContain("getServerSideProps");
+    expect(transformed).not.toContain("SERVER_SEED");
+    // The shadowing client local must survive so the component still works.
+    expect(transformed).toContain("value.toUpperCase()");
+    expect(transformed).toContain("default function Page");
+  });
+
+  it("keeps an import the client genuinely uses (shared with server code)", async () => {
+    const transformed = await createClientPageSource(
+      `
+        import { sharedFormat } from "./shared";
+        export const getServerSideProps = async () => ({
+          props: { s: sharedFormat("SEED") },
+        });
+        export default function Page({ items }) {
+          return <p>{sharedFormat(items[0])}</p>;
+        }
+      `,
+      "shared-import.tsrx",
+    );
+    // The client references the import at module scope (no shadow), so it must
+    // be preserved even though server code also uses it.
+    expect(transformed).toContain('from "./shared"');
+    expect(transformed).toContain("sharedFormat");
+    expect(transformed).not.toContain("getServerSideProps");
+  });
+
+  it("keeps an import used unshadowed in one scope even when shadowed in another", async () => {
+    const transformed = await createClientPageSource(
+      `
+        import { helper } from "./shared";
+        export const getServerSideProps = async () => ({
+          props: { s: helper("A") },
+        });
+        export default function Page() {
+          const outer = helper("B");
+          function inner() {
+            const helper = () => "local";
+            return helper();
+          }
+          return <p>{outer}{inner()}</p>;
+        }
+      `,
+      "mixed-shadow.tsrx",
+    );
+    // `helper("B")` is a real, unshadowed use of the import; a nested shadow in
+    // `inner` must not cause the import to be dropped.
+    expect(transformed).toContain('from "./shared"');
+    expect(transformed).toContain('helper("B")');
+  });
+
   it("keeps a non-exported local that shares a reserved server-export name", async () => {
     const transformed = await createClientPageSource(
       `


### PR DESCRIPTION
## Summary

The client-page stripper (`createClientPageSource` in `src/plugin.ts`) is a security boundary: server-only page code (`getServerSideProps`/`getStaticProps`/`getStaticPaths`/`config`/`getInitialProps` and anything they reference) must never reach the browser bundle.

It decided whether to keep an import with a purely **name-based** check — an import was retained whenever its binding name appeared *anywhere* in client code. That conflated a real reference to the module-level import with a **same-named local** declared in a client scope. So a server-only import (and the module it drags in) leaked into the browser bundle whenever a client component happened to reuse the imported name for a param or a local:

```jsx
import { helper } from "./server-only";       // used only in getServerSideProps
export const getServerSideProps = async () => ({ props: { x: helper() } });
export default function Page() {
  const helper = () => "client-local";        // shadows the import name
  return <p>{helper()}</p>;                    // uses the LOCAL, not the import
}
```

`clientReferences.has("helper")` was true (from the local), so `./server-only` was kept — a leak.

## Fix

Add a conservative, **scope-aware** reference check. An import now counts as "used by the client" only when client code references its name at a position where the module-level binding is still visible — not shadowed by an enclosing function/arrow param, a function-expression name, a catch param, a for-head declaration, or a block's own declarations.

The check is conservative in the safe direction: a reference is treated as shadowed **only when a real binding of the name is found in an enclosing scope**, so a genuinely-used or server/client-shared import is never dropped. Missing a shadow merely keeps an import that could have been removed — never the reverse (which would strip a used import and break the build).

## Verification

- `test/unit/plugin-security.test.ts` grows three regression tests:
  - the **leak** case — a server-only import shadowed by a client local is stripped;
  - the **must-keep** case — an import the client genuinely uses (shared with server code) is preserved;
  - the **mixed** case — an import used unshadowed in one scope while shadowed in a nested one is preserved.
- Full unit + security suite green: **111/111** (was 108).
- `tsc --noEmit` clean.
- The production **build-fixture** security test (a real Vite browser build asserting no server canaries/source-maps leak) passes, and `npm run build` succeeds — this is the true end-to-end gate for a bundler change.

This change is confined to the client bundler and does not touch runtime request handling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XN177Z1tvh3E4F1rx4DDRC)_